### PR TITLE
adds Github workflow to synchronize main branch and pull requests with GitLab

### DIFF
--- a/.github/workflows/clean-gitlab.yml
+++ b/.github/workflows/clean-gitlab.yml
@@ -1,0 +1,24 @@
+name: clean-gitlab
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  clean-gitlab:
+    runs-on: ubuntu-latest
+    steps:
+    - name: clean-gitlab
+      shell: bash
+      env:
+        GITLAB_ACCESS_TOKEN: ${{ secrets.GITLAB_ACCESS_TOKEN }}
+      run: |
+        # remove gitlab branch when pull request is closed
+        git init
+        git remote add gitlab https://clean-gitlab:$GITLAB_ACCESS_TOKEN@gitlab.mpi-sws.org/simbricks/simbricks.git
+        
+        # get branch name of pull request from GITHUB_REF, which has the format: refs/pull/<pr_number>/merge
+        BRANCH_NAME=${GITHUB_REF##*refs/}
+        BRANCH_NAME=${BRANCH_NAME%%/merge*}
+
+        git push gitlab --delete $BRANCH_NAME

--- a/.github/workflows/push-to-gitlab.yml
+++ b/.github/workflows/push-to-gitlab.yml
@@ -1,0 +1,32 @@
+name: push-to-gitlab
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  push-to-gitlab:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: push-to-gitlab
+      shell: bash
+      env:
+        GITLAB_ACCESS_TOKEN: ${{ secrets.GITLAB_ACCESS_TOKEN }}
+      run: |
+        git remote add gitlab https://push-to-gitlab:$GITLAB_ACCESS_TOKEN@gitlab.mpi-sws.org/simbricks/simbricks.git
+        
+        # transform GITHUB_REF to better branch_name, which defaults to refs/pull/<pr_number>/merge for pull requests
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]
+        then
+          BRANCH_NAME=${GITHUB_REF##*refs/}
+          BRANCH_NAME=${BRANCH_NAME%%/merge*}
+          git checkout -b $BRANCH_NAME
+          git push --force --set-upstream gitlab $BRANCH_NAME
+        else
+          BRANCH_NAME=$GITHUB_REF_NAME
+          git push --set-upstream gitlab $BRANCH_NAME
+        fi

--- a/.github/workflows/push-to-gitlab.yml
+++ b/.github/workflows/push-to-gitlab.yml
@@ -24,9 +24,11 @@ jobs:
         then
           BRANCH_NAME=${GITHUB_REF##*refs/}
           BRANCH_NAME=${BRANCH_NAME%%/merge*}
+          
           git checkout -b $BRANCH_NAME
           git push --force --set-upstream gitlab $BRANCH_NAME
         else
           BRANCH_NAME=$GITHUB_REF_NAME
+          
           git push --set-upstream gitlab $BRANCH_NAME
         fi


### PR DESCRIPTION
Requires a project access token for the repository on GitLab, which has to be added under Settings->Secrets->Actions as a repository secret called `GITLAB_ACCESS_TOKEN`.