### PR TITLE
fix experiments no longer working

### DIFF
--- a/experiments/pyexps/ae/f1_dctcp.py
+++ b/experiments/pyexps/ae/f1_dctcp.py
@@ -89,16 +89,16 @@ for mtu in types_of_mtu:
                 elif host == 'qt':
                     freq = cpu_freq_qemu
 
-                    def qemu_timing():
-                        h = sim.QemuHost()
+                    def qemu_timing(node_config: node.NodeConfig):
+                        h = sim.QemuHost(node_config)
                         h.sync = True
                         return h
 
                     HostClass = qemu_timing
                 elif host == 'gt':
 
-                    def gem5_timing():
-                        h = sim.Gem5Host()
+                    def gem5_timing(node_config: node.NodeConfig):
+                        h = sim.Gem5Host(node_config)
                         #h.sys_clock = sys_clock
                         return h
 
@@ -106,8 +106,8 @@ for mtu in types_of_mtu:
                     e.checkpoint = True
                 elif host == 'gO3':
 
-                    def gem5_o3():
-                        h = sim.Gem5Host()
+                    def gem5_o3(node_config: node.NodeConfig):
+                        h = sim.Gem5Host(node_config)
                         h.cpu_type = 'DerivO3CPU'
                         h.sys_clock = sys_clock
                         return h

--- a/experiments/pyexps/ae/f7_scale.py
+++ b/experiments/pyexps/ae/f7_scale.py
@@ -86,8 +86,8 @@ for n_client in num_client_types:
                     HostClass = sim.QemuHost
                 elif host_type == 'qt':
 
-                    def qemu_timing():
-                        h = sim.QemuHost()
+                    def qemu_timing(node_config: node.NodeConfig):
+                        h = sim.QemuHost(node_config)
                         h.sync = True
                         return h
 

--- a/experiments/pyexps/ae/no_simbricks.py
+++ b/experiments/pyexps/ae/no_simbricks.py
@@ -39,9 +39,6 @@ for app_type in app_types:
     NcClass = node.I40eLinuxNode
     # create servers and clients
 
-    host = HostClass()
-    host.name = 'host.0'
-    host.cpu_freq = '3GHz'
     node_config = NcClass()
     node_config.ip = '10.0.0.1'
     node_config.app = node.NoTraffic()
@@ -53,7 +50,10 @@ for app_type in app_types:
     else:
         node_config.app.is_sleep = 0
 
-    host.set_config(node_config)
+    host = HostClass(node_config)
+    host.name = 'host.0'
+    host.cpu_freq = '3GHz'
+
     e.add_host(host)
     host.wait = True
 

--- a/experiments/pyexps/ae/no_traffic.py
+++ b/experiments/pyexps/ae/no_traffic.py
@@ -59,8 +59,8 @@ for host_type in host_types:
                     HostClass = sim.QemuHost
                 elif host_type == 'qt':
 
-                    def qemu_timing():
-                        h = sim.QemuHost()
+                    def qemu_timing(node_config: node.NodeConfig):
+                        h = sim.QemuHost(node_config)
                         h.sync = True
                         return h
 

--- a/experiments/pyexps/ae/nopaxos.py
+++ b/experiments/pyexps/ae/nopaxos.py
@@ -62,8 +62,8 @@ for proto_config in proto_configs:
                         e.checkpoint = True
                     elif host_config == 'qt':
 
-                        def qemu_timing():
-                            h = sim.QemuHost()
+                        def qemu_timing(node_config: node.NodeConfig):
+                            h = sim.QemuHost(node_config)
                             h.sync = True
                             return h
 

--- a/experiments/pyexps/ae/t1_netperf.py
+++ b/experiments/pyexps/ae/t1_netperf.py
@@ -73,8 +73,8 @@ for host_type in host_types:
                 HostClass = sim.QemuHost
             elif host_type == 'qt':
 
-                def qemu_timing():
-                    h = sim.QemuHost()
+                def qemu_timing(node_config: node.NodeConfig):
+                    h = sim.QemuHost(node_config)
                     h.sync = True
                     return h
 

--- a/experiments/pyexps/dctcp.py
+++ b/experiments/pyexps/dctcp.py
@@ -77,16 +77,16 @@ for mtu in types_of_mtu:
                 elif host == 'qt':
                     freq = cpu_freq_qemu
 
-                    def qemu_timing():
-                        h = sim.QemuHost()
+                    def qemu_timing(node_config: node.NodeConfig):
+                        h = sim.QemuHost(node_config)
                         h.sync = True
                         return h
 
                     HostClass = qemu_timing
                 elif host == 'gt':
 
-                    def gem5_timing():
-                        h = sim.Gem5Host()
+                    def gem5_timing(node_config: node.NodeConfig):
+                        h = sim.Gem5Host(node_config)
                         #h.sys_clock = sys_clock
                         return h
 
@@ -94,8 +94,8 @@ for mtu in types_of_mtu:
                     e.checkpoint = True
                 elif host == 'gO3':
 
-                    def gem5_o3():
-                        h = sim.Gem5Host()
+                    def gem5_o3(node_config: node.NodeConfig):
+                        h = sim.Gem5Host(node_config)
                         h.cpu_type = 'DerivO3CPU'
                         h.sys_clock = sys_clock
                         return h

--- a/experiments/pyexps/dist_memcache.py
+++ b/experiments/pyexps/dist_memcache.py
@@ -78,8 +78,8 @@ for host_type in host_types:
                 HostClass = sim.QemuHost
             elif host_type == 'qt':
 
-                def qemu_timing():
-                    h = sim.QemuHost()
+                def qemu_timing(node_config: node.NodeConfig):
+                    h = sim.QemuHost(node_config)
                     h.sync = True
                     return h
 

--- a/experiments/pyexps/dist_multinet.py
+++ b/experiments/pyexps/dist_multinet.py
@@ -46,8 +46,8 @@ for host_type in host_types:
                 HostClass = sim.QemuHost
             elif host_type == 'qt':
 
-                def qemu_timing():
-                    h = sim.QemuHost()
+                def qemu_timing(node_config: node.NodeConfig):
+                    h = sim.QemuHost(node_config)
                     h.sync = True
                     return h
 

--- a/experiments/pyexps/dist_netperf.py
+++ b/experiments/pyexps/dist_netperf.py
@@ -47,8 +47,8 @@ for host_type in host_types:
                 net.sync = False
             elif host_type == 'qt':
 
-                def qemu_timing():
-                    h = sim.QemuHost()
+                def qemu_timing(node_config: node.NodeConfig):
+                    h = sim.QemuHost(node_config)
                     h.sync = True
                     return h
 

--- a/experiments/pyexps/femutest.py
+++ b/experiments/pyexps/femutest.py
@@ -30,18 +30,17 @@ for h in ['qk', 'gk']:
     e = exp.Experiment('femutest-' + h)
     e.checkpoint = False
 
-    if h == 'gk':
-        host = sim.Gem5Host()
-        host.cpu_type = 'X86KvmCPU'
-    elif h == 'qk':
-        host = sim.QemuHost()
-    host.name = 'host.0'
     node_config = node.LinuxFEMUNode()
     node_config.app = node.NVMEFsTest()
     node_config.cores = 1
-
     node_config.app.is_sleep = 1
-    host.set_config(node_config)
+
+    if h == 'gk':
+        host = sim.Gem5Host(node_config)
+        host.cpu_type = 'X86KvmCPU'
+    elif h == 'qk':
+        host = sim.QemuHost(node_config)
+    host.name = 'host.0'
     e.add_host(host)
     host.wait = True
 

--- a/experiments/pyexps/modetcp.py
+++ b/experiments/pyexps/modetcp.py
@@ -62,16 +62,16 @@ for mode in types_of_mode:
                     HostClass = sim.QemuHost
                 elif host == 'qt':
 
-                    def qemu_timing():
-                        h = sim.QemuHost()
+                    def qemu_timing(node_config: node.NodeConfig):
+                        h = sim.QemuHost(node_config)
                         h.sync = True
                         return h
 
                     HostClass = qemu_timing
                 elif host == 'gt':
 
-                    def gem5_timing():
-                        h = sim.Gem5Host()
+                    def gem5_timing(node_config: node.NodeConfig):
+                        h = sim.Gem5Host(node_config)
                         return h
 
                     HostClass = gem5_timing

--- a/experiments/pyexps/netperf.py
+++ b/experiments/pyexps/netperf.py
@@ -60,8 +60,8 @@ for host_type in host_types:
                 HostClass = sim.QemuHost
             elif host_type == 'qt':
 
-                def qemu_timing():
-                    h = sim.QemuHost()
+                def qemu_timing(node_config: node.NodeConfig):
+                    h = sim.QemuHost(node_config)
                     h.sync = True
                     return h
 

--- a/experiments/pyexps/no_simbricks.py
+++ b/experiments/pyexps/no_simbricks.py
@@ -39,8 +39,6 @@ for app_type in app_types:
     NcClass = node.I40eLinuxNode
     # create servers and clients
 
-    host = HostClass()
-    host.name = 'host.0'
     node_config = NcClass()
     node_config.ip = '10.0.0.1'
     node_config.app = node.NoTraffic()
@@ -52,7 +50,9 @@ for app_type in app_types:
     else:
         node_config.app.is_sleep = 0
 
-    host.set_config(node_config)
+    host = HostClass(node_config)
+    host.name = 'host.0'
+
     e.add_host(host)
     host.wait = True
 

--- a/experiments/pyexps/no_traffic.py
+++ b/experiments/pyexps/no_traffic.py
@@ -66,8 +66,8 @@ for host_type in host_types:
                     HostClass = sim.QemuHost
                 elif host_type == 'qt':
 
-                    def qemu_timing():
-                        h = sim.QemuHost()
+                    def qemu_timing(node_config: node.NodeConfig):
+                        h = sim.QemuHost(node_config)
                         h.sync = True
                         return h
 

--- a/experiments/pyexps/nopaxos.py
+++ b/experiments/pyexps/nopaxos.py
@@ -62,8 +62,8 @@ for proto_config in proto_configs:
                         e.checkpoint = True
                     elif host_config == 'qt':
 
-                        def qemu_timing():
-                            h = sim.QemuHost()
+                        def qemu_timing(node_config: node.NodeConfig):
+                            h = sim.QemuHost(node_config)
                             h.sync = True
                             return h
 

--- a/experiments/pyexps/pci_validation.py
+++ b/experiments/pyexps/pci_validation.py
@@ -39,18 +39,18 @@ for internal in [True, False]:
     net = sim.SwitchNet()
     e.add_network(net)
 
-    server = sim.Gem5Host()
-    server.name = 'server'
+    # server
     nc_server = node.E1000LinuxNode()
     nc_server.prefix = 24
     nc_server.ip = '10.0.0.1'
     nc_server.force_mac_addr = '00:90:00:00:00:01'
     nc_server.app = node.NetperfServer()
-    server.set_config(nc_server)
+
+    server = sim.Gem5Host(nc_server)
+    server.name = 'server'
     e.add_host(server)
 
-    client = sim.Gem5Host()
-    client.name = 'client'
+    # client
     nc_client = node.E1000LinuxNode()
     nc_client.prefix = 24
     nc_client.ip = '10.0.0.2'
@@ -59,7 +59,9 @@ for internal in [True, False]:
     nc_client.app.server_ip = '10.0.0.1'
     nc_client.app.duration_tp = -1000000
     nc_client.app.duration_lat = -1000
-    client.set_config(nc_client)
+
+    client = sim.Gem5Host(nc_client)
+    client.name = 'client'
     client.wait = True
     e.add_host(client)
 

--- a/experiments/pyexps/scale_host.py
+++ b/experiments/pyexps/scale_host.py
@@ -74,8 +74,8 @@ for n_client in num_client_types:
                     HostClass = sim.QemuHost
                 elif host_type == 'qt':
 
-                    def qemu_timing():
-                        h = sim.QemuHost()
+                    def qemu_timing(node_config: node.NodeConfig):
+                        h = sim.QemuHost(node_config)
                         h.sync = True
                         return h
 

--- a/experiments/pyexps/scale_load.py
+++ b/experiments/pyexps/scale_load.py
@@ -72,8 +72,8 @@ for rate in rate_types:
                     HostClass = sim.QemuHost
                 elif host_type == 'qt':
 
-                    def qemu_timing():
-                        h = sim.QemuHost()
+                    def qemu_timing(node_config: node.NodeConfig):
+                        h = sim.QemuHost(node_config)
                         h.sync = True
                         return h
 

--- a/experiments/run.py
+++ b/experiments/run.py
@@ -308,8 +308,15 @@ if not args.pickled:
     for path in args.experiments:
         modname, _ = os.path.splitext(os.path.basename(path))
 
+        class ExperimentModuleLoadError(Exception):
+            pass
+
         spec = importlib.util.spec_from_file_location(modname, path)
+        if spec is None:
+            raise ExperimentModuleLoadError('spec is None')
         mod = importlib.util.module_from_spec(spec)
+        if spec.loader is None:
+            raise ExperimentModuleLoadError('spec.loader is None')
         spec.loader.exec_module(mod)
         experiments += mod.experiments
 

--- a/experiments/simbricks/experiments.py
+++ b/experiments/simbricks/experiments.py
@@ -44,13 +44,13 @@ class Experiment(object):
     the experiment.
     """
 
-    def __init__(self, name: str, timeout: int = 0):
+    def __init__(self, name: str):
         self.name = name
         """
         This experiment's name. Can be used to filter multiple experiments to be
         run.
         """
-        self.timeout = timeout
+        self.timeout: tp.Optional[int] = None
         """Timeout for experiment in seconds."""
         self.checkpoint = False
         """Whether to use checkpoints in experiment.

--- a/experiments/simbricks/nodeconfig.py
+++ b/experiments/simbricks/nodeconfig.py
@@ -51,6 +51,7 @@ class NodeConfig(object):
 
     def __init__(self):
         """Manages the configuration for a node."""
+        super().__init__()
         self.sim = 'qemu'
         """Name of simulator to run."""
         self.ip = '10.0.0.1'

--- a/experiments/simbricks/nodeconfig.py
+++ b/experiments/simbricks/nodeconfig.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import io
 import tarfile
+import typing as tp
 
 
 class AppConfig(object):
@@ -47,25 +48,27 @@ class AppConfig(object):
 
 
 class NodeConfig(object):
-    """Manages the configuration for a node."""
-    sim = 'qemu'
-    """Name of simulator to run."""
-    ip = '10.0.0.1'
-    """IP address."""
-    prefix = 24
-    """IP prefix."""
-    cores = 1
-    """Number of cores to be simulated."""
-    memory = 8 * 1024
-    """Amount of system memory in MB."""
-    disk_image = 'base'
-    """Disk image to use."""
-    app: AppConfig = None
-    """App to be run on simulated host."""
-    mtu = 1500
-    """Networking MTU."""
-    nockp = 0
-    """Do not make checkpoint in Gem5."""
+
+    def __init__(self):
+        """Manages the configuration for a node."""
+        self.sim = 'qemu'
+        """Name of simulator to run."""
+        self.ip = '10.0.0.1'
+        """IP address."""
+        self.prefix = 24
+        """IP prefix."""
+        self.cores = 1
+        """Number of cores to be simulated."""
+        self.memory = 8 * 1024
+        """Amount of system memory in MB."""
+        self.disk_image = 'base'
+        """Disk image to use."""
+        self.mtu = 1500
+        """Networking MTU."""
+        self.nockp = 0
+        """Do not make checkpoint in Gem5."""
+        self.app: tp.Optional[AppConfig] = None
+        """App to be run on simulated host."""
 
     def config_str(self):
         if self.sim == 'qemu':
@@ -131,9 +134,10 @@ class NodeConfig(object):
 
 
 class LinuxNode(NodeConfig):
-    ifname = 'eth0'
 
     def __init__(self):
+        super().__init__()
+        self.ifname = 'eth0'
         self.drivers = []
         self.force_mac_addr = None
 
@@ -181,10 +185,13 @@ class E1000LinuxNode(LinuxNode):
 
 
 class MtcpNode(NodeConfig):
-    disk_image = 'mtcp'
-    pci_dev = '0000:00:02.0'
-    memory = 16 * 1024
-    num_hugepages = 4096
+
+    def __init__(self):
+        super().__init__()
+        self.disk_image = 'mtcp'
+        self.pci_dev = '0000:00:02.0'
+        self.memory = 16 * 1024
+        self.num_hugepages = 4096
 
     def prepare_pre_cp(self):
         return super().prepare_pre_cp() + [
@@ -231,12 +238,15 @@ class MtcpNode(NodeConfig):
 
 
 class TASNode(NodeConfig):
-    disk_image = 'tas'
-    pci_dev = '0000:00:02.0'
-    memory = 16 * 1024
-    num_hugepages = 4096
-    fp_cores = 1
-    preload = True
+
+    def __init__(self):
+        super().__init__()
+        self.disk_image = 'tas'
+        self.pci_dev = '0000:00:02.0'
+        self.memory = 16 * 1024
+        self.num_hugepages = 4096
+        self.fp_cores = 1
+        self.preload = True
 
     def prepare_pre_cp(self):
         return super().prepare_pre_cp() + [
@@ -325,6 +335,7 @@ class CorundumDCTCPNode(NodeConfig):
 class LinuxFEMUNode(NodeConfig):
 
     def __init__(self):
+        super().__init__()
         self.drivers = ['nvme']
 
     def prepare_post_cp(self):
@@ -355,8 +366,11 @@ class DctcpServer(AppConfig):
 
 
 class DctcpClient(AppConfig):
-    server_ip = '192.168.64.1'
-    is_last = False
+
+    def __init__(self):
+        super().__init__()
+        self.server_ip = '192.168.64.1'
+        self.is_last = False
 
     def run_cmds(self, node):
         if self.is_last:
@@ -374,7 +388,10 @@ class DctcpClient(AppConfig):
 
 
 class PingClient(AppConfig):
-    server_ip = '192.168.64.1'
+
+    def __init__(self):
+        super().__init__()
+        self.server_ip = '192.168.64.1'
 
     def run_cmds(self, node):
         return [f'ping {self.server_ip} -c 100']
@@ -393,9 +410,12 @@ class IperfUDPServer(AppConfig):
 
 
 class IperfTCPClient(AppConfig):
-    server_ip = '10.0.0.1'
-    procs = 1
-    is_last = False
+
+    def __init__(self):
+        super().__init__()
+        self.server_ip = '10.0.0.1'
+        self.procs = 1
+        self.is_last = False
 
     def run_cmds(self, node):
 
@@ -412,9 +432,12 @@ class IperfTCPClient(AppConfig):
 
 
 class IperfUDPClient(AppConfig):
-    server_ip = '10.0.0.1'
-    rate = '150m'
-    is_last = False
+
+    def __init__(self):
+        super().__init__()
+        self.server_ip = '10.0.0.1'
+        self.rate = '150m'
+        self.is_last = False
 
     def run_cmds(self, node):
         cmds = [
@@ -431,9 +454,12 @@ class IperfUDPClient(AppConfig):
 
 
 class IperfUDPShortClient(AppConfig):
-    server_ip = '10.0.0.1'
-    rate = '150m'
-    is_last = False
+
+    def __init__(self):
+        super().__init__()
+        self.server_ip = '10.0.0.1'
+        self.rate = '150m'
+        self.is_last = False
 
     def run_cmds(self, node):
         cmds = ['sleep 1', 'iperf -c ' + self.server_ip + ' -u -n 1 ']
@@ -442,16 +468,22 @@ class IperfUDPShortClient(AppConfig):
 
 
 class IperfUDPClientSleep(AppConfig):
-    server_ip = '10.0.0.1'
-    rate = '150m'
+
+    def __init__(self):
+        super().__init__()
+        self.server_ip = '10.0.0.1'
+        self.rate = '150m'
 
     def run_cmds(self, node):
         return ['sleep 1', 'sleep 10']
 
 
 class NoTraffic(AppConfig):
-    is_sleep = 1
-    is_server = 0
+
+    def __init__(self):
+        super().__init__()
+        self.is_sleep = 1
+        self.is_server = 0
 
     def run_cmds(self, node):
         cmds = []
@@ -474,9 +506,12 @@ class NetperfServer(AppConfig):
 
 
 class NetperfClient(AppConfig):
-    server_ip = '10.0.0.1'
-    duration_tp = 10
-    duration_lat = 10
+
+    def __init__(self):
+        super().__init__()
+        self.server_ip = '10.0.0.1'
+        self.duration_tp = 10
+        self.duration_lat = 10
 
     def run_cmds(self, node):
         return [
@@ -491,7 +526,10 @@ class NetperfClient(AppConfig):
 
 
 class VRReplica(AppConfig):
-    index = 0
+
+    def __init__(self):
+        super().__init__()
+        self.index = 0
 
     def run_cmds(self, node):
         return [
@@ -501,7 +539,10 @@ class VRReplica(AppConfig):
 
 
 class VRClient(AppConfig):
-    server_ips = []
+
+    def __init__(self):
+        super().__init__()
+        self.server_ips = []
 
     def run_cmds(self, node):
         cmds = []
@@ -515,7 +556,10 @@ class VRClient(AppConfig):
 
 
 class NOPaxosReplica(AppConfig):
-    index = 0
+
+    def __init__(self):
+        super().__init__()
+        self.index = 0
 
     def run_cmds(self, node):
         return [
@@ -525,9 +569,12 @@ class NOPaxosReplica(AppConfig):
 
 
 class NOPaxosClient(AppConfig):
-    server_ips = []
-    is_last = False
-    use_ehseq = False
+
+    def __init__(self):
+        super().__init__()
+        self.server_ips = []
+        self.is_last = False
+        self.use_ehseq = False
 
     def run_cmds(self, node):
         cmds = []
@@ -555,10 +602,13 @@ class NOPaxosSequencer(AppConfig):
 
 
 class RPCServer(AppConfig):
-    port = 1234
-    threads = 1
-    max_flows = 1234
-    max_bytes = 1024
+
+    def __init__(self):
+        super().__init__()
+        self.port = 1234
+        self.threads = 1
+        self.max_flows = 1234
+        self.max_bytes = 1024
 
     def run_cmds(self, node):
         exe = 'echoserver_linux' if not isinstance(node, MtcpNode) else \
@@ -573,16 +623,19 @@ class RPCServer(AppConfig):
 
 
 class RPCClient(AppConfig):
-    server_ip = '10.0.0.1'
-    port = 1234
-    threads = 1
-    max_flows = 128
-    max_bytes = 1024
-    max_pending = 1
-    openall_delay = 2
-    max_msgs_conn = 0
-    max_pend_conns = 8
-    time = 25
+
+    def __init__(self):
+        super().__init__()
+        self.server_ip = '10.0.0.1'
+        self.port = 1234
+        self.threads = 1
+        self.max_flows = 128
+        self.max_bytes = 1024
+        self.max_pending = 1
+        self.openall_delay = 2
+        self.max_msgs_conn = 0
+        self.max_pend_conns = 8
+        self.time = 25
 
     def run_cmds(self, node):
         exe = 'testclient_linux' if not isinstance(node, MtcpNode) else \
@@ -603,10 +656,13 @@ class RPCClient(AppConfig):
 
 
 class HTTPD(AppConfig):
-    threads = 1
-    file_size = 64
-    mtcp_config = 'lighttpd.conf'
-    httpd_dir: str  # TODO added because doesn't originally exist
+
+    def __init__(self):
+        super().__init__()
+        self.threads = 1
+        self.file_size = 64
+        self.mtcp_config = 'lighttpd.conf'
+        self.httpd_dir = ''  # TODO added because doesn't originally exist
 
     def prepare_pre_cp(self):
         return [
@@ -628,16 +684,25 @@ class HTTPD(AppConfig):
 
 
 class HTTPDLinux(HTTPD):
-    httpd_dir = '/root/mtcp/apps/lighttpd-mtlinux'
+
+    def __init__(self):
+        super().__init__()
+        self.httpd_dir = '/root/mtcp/apps/lighttpd-mtlinux'
 
 
 class HTTPDLinuxRPO(HTTPD):
-    httpd_dir = '/root/mtcp/apps/lighttpd-mtlinux-rop'
+
+    def __init__(self):
+        super().__init__()
+        self.httpd_dir = '/root/mtcp/apps/lighttpd-mtlinux-rop'
 
 
 class HTTPDMtcp(HTTPD):
-    httpd_dir = '/root/mtcp/apps/lighttpd-mtcp'
-    mtcp_config = 'm-lighttpd.conf'
+
+    def __init__(self):
+        super().__init__()
+        self.httpd_dir = '/root/mtcp/apps/lighttpd-mtcp'
+        self.mtcp_config = 'm-lighttpd.conf'
 
     def prepare_pre_cp(self):
         return super().prepare_pre_cp() + [
@@ -651,13 +716,16 @@ class HTTPDMtcp(HTTPD):
 
 
 class HTTPC(AppConfig):
-    server_ip = '10.0.0.1'
-    conns = 1000
-    #requests = 10000000
-    requests = 10000
-    threads = 1
-    url = '/file'
-    ab_dir: str  # TODO added because doesn't originally exist
+
+    def __init__(self):
+        super().__init__()
+        self.server_ip = '10.0.0.1'
+        self.conns = 1000
+        #self.requests = 10000000
+        self.requests = 10000
+        self.threads = 1
+        self.url = '/file'
+        self.ab_dir = ''  # TODO added because doesn't originally exist
 
     def run_cmds(self, node):
         return [
@@ -670,11 +738,17 @@ class HTTPC(AppConfig):
 
 
 class HTTPCLinux(HTTPC):
-    ab_dir = '/root/mtcp/apps/ab-linux'
+
+    def __init__(self):
+        super().__init__()
+        self.ab_dir = '/root/mtcp/apps/ab-linux'
 
 
 class HTTPCMtcp(HTTPC):
-    ab_dir = '/root/mtcp/apps/ab-mtcp'
+
+    def __init__(self):
+        super().__init__()
+        self.ab_dir = '/root/mtcp/apps/ab-mtcp'
 
     def prepare_pre_cp(self):
         return super().prepare_pre_cp() + [
@@ -690,10 +764,13 @@ class MemcachedServer(AppConfig):
 
 
 class MemcachedClient(AppConfig):
-    server_ips = ['10.0.0.1']
-    threads = 1
-    concurrency = 1
-    throughput = '1k'
+
+    def __init__(self):
+        super().__init__()
+        self.server_ips = ['10.0.0.1']
+        self.threads = 1
+        self.concurrency = 1
+        self.throughput = '1k'
 
     def run_cmds(self, node):
         servers = [ip + ':11211' for ip in self.server_ips]

--- a/experiments/simbricks/simulator_utils.py
+++ b/experiments/simbricks/simulator_utils.py
@@ -54,15 +54,14 @@ def create_basic_hosts(
         #nic.name = '%s.%d' % (name_prefix, i)
         nic.set_network(net)
 
-        host = host_class()
-        host.name = f'{name_prefix}.{i}'
-
         node_config = nc_class()
         node_config.prefix = ip_prefix
         ip = ip_start + i
         node_config.ip = f'10.0.{int(ip / 256)}.{ip % 256}'
         node_config.app = app_class()
-        host.set_config(node_config)
+
+        host = host_class(node_config)
+        host.name = f'{name_prefix}.{i}'
 
         host.add_nic(nic)
         e.add_nic(nic)
@@ -103,15 +102,14 @@ def create_multinic_hosts(
         #nic.name = '%s.%d' % (name_prefix, i)
         nic.set_network(net)
 
-        host = host_class()
-        host.name = f'{name_prefix}.{i}'
-
         node_config = nc_class()
         node_config.prefix = ip_prefix
         ip = ip_start + i
         node_config.ip = f'10.0.{int(ip / 256)}.{ip % 256}'
         node_config.app = app_class()
-        host.set_config(node_config)
+
+        host = host_class(node_config)
+        host.name = f'{name_prefix}.{i}'
 
         host.add_nic(nic)
         e.add_host(host)
@@ -148,15 +146,14 @@ def create_dctcp_hosts(
         #nic.name = '%s.%d' % (name_prefix, i)
         nic.set_network(net)
 
-        host = host_class()
-        host.name = f'{name_prefix}.{i}'
-        host.cpu_freq = cpu_freq
-
         node_config = nc_class()
         node_config.mtu = mtu
         node_config.ip = f'192.168.64.{ip_start + i}'
         node_config.app = app_class()
-        host.set_config(node_config)
+
+        host = host_class(node_config)
+        host.name = f'{name_prefix}.{i}'
+        host.cpu_freq = cpu_freq
 
         host.add_nic(nic)
         e.add_nic(nic)

--- a/experiments/simbricks/simulators.py
+++ b/experiments/simbricks/simulators.py
@@ -118,8 +118,8 @@ class NICSim(PCIDevSim):
     def basic_args(self, env, extra=None):
         cmd = (
             f'{env.dev_pci_path(self)} {env.nic_eth_path(self)}'
-            f' {env.dev_shm_path(self)} {self.sync_mode} {self.sync_period}'
-            f' {self.start_tick} {self.pci_latency} {self.eth_latency}'
+            f' {env.dev_shm_path(self)} {self.sync_mode} {self.start_tick}'
+            f' {self.sync_period} {self.pci_latency} {self.eth_latency}'
         )
         if self.mac is not None:
             cmd += ' ' + (''.join(reversed(self.mac.split(':'))))

--- a/experiments/simbricks/simulators.py
+++ b/experiments/simbricks/simulators.py
@@ -195,9 +195,9 @@ class NetSim(Simulator):
 class HostSim(Simulator):
     """Base class for host simulators."""
 
-    def __init__(self):
+    def __init__(self, node_config: NodeConfig):
         super().__init__()
-        self.node_config: tp.Optional[NodeConfig] = None
+        self.node_config = node_config
         """Config for the simulated host. """
         self.name = ''
         self.wait = False
@@ -229,9 +229,6 @@ class HostSim(Simulator):
         net.hosts_direct.append(self)
         self.net_directs.append(net)
 
-    def set_config(self, nc: NodeConfig):
-        self.node_config = nc
-
     def dependencies(self):
         deps = []
         for dev in self.pcidevs:
@@ -247,8 +244,8 @@ class HostSim(Simulator):
 class QemuHost(HostSim):
     """Qemu host simulator."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, node_config: NodeConfig):
+        super().__init__(node_config)
 
         self.sync = False
         self.cpu_freq = '4GHz'
@@ -314,18 +311,15 @@ class QemuHost(HostSim):
 class Gem5Host(HostSim):
     """Gem5 host simulator."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, node_config: NodeConfig):
+        node_config.sim = 'gem5'
+        super().__init__(node_config)
         self.cpu_type_cp = 'X86KvmCPU'
         self.cpu_type = 'TimingSimpleCPU'
         self.sys_clock = '1GHz'
         self.extra_main_args = []
         self.extra_config_args = []
         self.variant = 'fast'
-
-    def set_config(self, nc):
-        nc.sim = 'gem5'
-        super().set_config(nc)
 
     def resreq_cores(self):
         return 1


### PR DESCRIPTION
Having a mutable default value for a class variable is dangerous, as the mutable default value will be shared across all instances. See [here](https://docs.python.org/3/library/dataclasses.html#mutable-default-values) for more information. I did exactly this mistake in https://github.com/simbricks/simbricks/pull/21, which means that most experiments are currently failing to even start up the simulators. To prevent this issue in the future and not have a mixture of declaring class attributes in two different places (as class or instance variable), I moved everything to `__init__`.

Additionally, I fixed a typo in the class `NICSim`, which led to the i40e simulator being stuck at timestamp 500.

I tested the netperf experiment in the configuration `qemu-switch-i40e` and it is now producing results again.