### PR TITLE
fix pytype not detecting broken auto_dist()

### DIFF
--- a/experiments/simbricks/experiments.py
+++ b/experiments/simbricks/experiments.py
@@ -49,13 +49,13 @@ class Experiment(object):
         self.timeout: tp.Optional[int] = None
         """Timeout for experiment in seconds."""
         self.checkpoint = False
-        """Whether to use checkpoints in experiment.
+        """Whether to use checkpoints in the experiment.
 
         Using this property we can, for example, speed up booting a host
         simulator by first running in a less accurate mode. Before we then start
-        the measurement we are interested in, a checkpoint is taken and the
-        simulator shut down, a check point created, and finally restored in the
-        accurate mode using this checkpoint."""
+        the measurement we are interested in, a checkpoint is taken, the
+        simulator shut down and finally restored in the accurate mode using this
+        checkpoint."""
         self.no_simbricks = False
         """If `true`, no simbricks adapters are used in any of the
         simulators."""

--- a/experiments/simbricks/experiments.py
+++ b/experiments/simbricks/experiments.py
@@ -37,34 +37,32 @@ from simbricks.utils import graphlib
 
 
 class Experiment(object):
-    """
-    Describes a simulation experiment.
-
-    Holds information about the simulators to run and paramaters to configure
-    the experiment.
-    """
+    """Base class for all simulation experiments."""
 
     def __init__(self, name: str):
         self.name = name
         """
-        This experiment's name. Can be used to filter multiple experiments to be
-        run.
+        This experiment's name. Can be used to run only a selection of
+        experiments.
         """
         self.timeout: tp.Optional[int] = None
         """Timeout for experiment in seconds."""
         self.checkpoint = False
         """Whether to use checkpoints in experiment.
 
-        Can for example be used to speed up booting a host simulator by first
-        running in a less accurate mode. Before we then start the application we
-        are interested in, a checkpoint is taken and the simulator shut down.
-        Then, the simulator is restored in the accurate mode using this
-        checkpoint."""
+        Using this property we can, for example, speed up booting a host
+        simulator by first running in a less accurate mode. Before we then start
+        the measurement we are interested in, a checkpoint is taken and the
+        simulator shut down, a check point created, and finally restored in the
+        accurate mode using this checkpoint."""
         self.no_simbricks = False
-        """`true` - No simbricks adapters are used in the simulators."""
+        """If `true`, no simbricks adapters are used in any of the simulators."""
         self.hosts: tp.List[HostSim] = []
+        """The host simulators to run."""
         self.pcidevs: tp.List[PCIDevSim] = []
+        """The PCIe device simulators to run."""
         self.networks: tp.List[NetSim] = []
+        """The network simulators to run."""
         self.metadata = {}
 
     def add_host(self, sim: HostSim):
@@ -150,7 +148,7 @@ T = tp.TypeVar('T', bound=Experiment)
 class ExperimentBaseRunner(tp.Generic[T]):
 
     def __init__(self, exp: T, env: ExpEnv, verbose: bool):
-        self.exp: T = exp
+        self.exp = exp
         self.env = env
         self.verbose = verbose
         self.out = ExpOutput(exp)

--- a/experiments/simbricks/experiments.py
+++ b/experiments/simbricks/experiments.py
@@ -316,7 +316,7 @@ class ExperimentBaseRunner(ABC):
 class ExperimentSimpleRunner(ExperimentBaseRunner):
     """Simple experiment runner with just one executor."""
 
-    def __init__(self, executor: Executor, exp: Experiment, *args, **kwargs):
+    def __init__(self, executor: Executor, *args, **kwargs):
         self.executor = executor
         super().__init__(*args, **kwargs)
 
@@ -329,7 +329,7 @@ class ExperimentDistributedRunner(ExperimentBaseRunner):
 
     def __init__(self, execs, exp: DistributedExperiment, *args, **kwargs):
         self.execs = execs
-        super().__init__(*args, **kwargs)
+        super().__init__(exp, *args, **kwargs)
         self.exp = exp  # overrides the type in the base class
         assert self.exp.num_hosts <= len(execs)
 

--- a/experiments/simbricks/runtime/distributed.py
+++ b/experiments/simbricks/runtime/distributed.py
@@ -33,8 +33,8 @@ from simbricks.runtime.common import Run, Runtime
 class DistributedSimpleRuntime(Runtime):
 
     def __init__(self, executors, verbose=False):
-        self.runnable = []
-        self.complete = []
+        self.runnable: tp.List[Run] = []
+        self.complete: tp.List[Run] = []
         self.verbose = verbose
         self.executors = executors
 
@@ -46,7 +46,11 @@ class DistributedSimpleRuntime(Runtime):
 
     async def do_run(self, run: Run):
         runner = exp.ExperimentDistributedRunner(
-            self.executors, run.experiment, run.env, self.verbose
+            self.executors,
+            # we ensure the correct type in add_run()
+            tp.cast(exp.DistributedExperiment, run.experiment),
+            run.env,
+            self.verbose
         )
         for executor in self.executors:
             await run.prep_dirs(executor)


### PR DESCRIPTION
Fixes the remaining remark in #25. `pytype` currently seems buggy when using Generics for type annotation. It behaves as if we specified `Any` for the type of an class attribute meaning that it doesn't check anything. To solve this, I replaced the use of Generics with overriding the type of the attribute in the subclass.

I also investigated using `pyright` or `mytype`. Both face the issue that they report errors on code that actually has correct dynamic behavior doesn't necessarily use any incomprehensible Python trickery to do so. The fix for many of these errors is to add more code which does not ease understanding. It therefore makes sense to stick with pytype and hack our way around this issue.