### PR TITLE
sims/nic/i40e_bm: fix logger segfault due to constructors

### DIFF
--- a/sims/nic/i40e_bm/i40e_bm.cc
+++ b/sims/nic/i40e_bm/i40e_bm.cc
@@ -36,7 +36,7 @@
 namespace i40e {
 
 i40e_bm::i40e_bm()
-    : log("i40e", runner_),
+    : log("i40e", *this),
       pf_atq(*this, regs.pf_atqba, regs.pf_atqlen, regs.pf_atqh, regs.pf_atqt),
       hmc(*this),
       shram(*this),
@@ -754,7 +754,7 @@ void i40e_bm::reset(bool indicate_done) {
   regs.glrpb_plw = 0x0846;
 }
 
-shadow_ram::shadow_ram(i40e_bm &dev_) : dev(dev_), log("sram", dev_.runner_) {
+shadow_ram::shadow_ram(i40e_bm &dev_) : dev(dev_), log("sram", dev_) {
 }
 
 void shadow_ram::reg_updated() {

--- a/sims/nic/i40e_bm/i40e_bm.h
+++ b/sims/nic/i40e_bm/i40e_bm.h
@@ -68,11 +68,12 @@ class logger : public std::ostream {
 
  protected:
   std::string label;
+  nicbm::Runner::Device &dev;
   nicbm::Runner *runner;
   std::stringstream ss;
 
  public:
-  explicit logger(const std::string &label_, nicbm::Runner *runner_);
+  explicit logger(const std::string &label_, nicbm::Runner::Device &dev_);
   logger &operator<<(char c);
   logger &operator<<(int32_t c);
   logger &operator<<(uint8_t i);

--- a/sims/nic/i40e_bm/i40e_lan.cc
+++ b/sims/nic/i40e_bm/i40e_lan.cc
@@ -37,7 +37,7 @@ namespace i40e {
 
 lan::lan(i40e_bm &dev_, size_t num_qs_)
     : dev(dev_),
-      log("lan", dev_.runner_),
+      log("lan", dev_),
       rss_kc(dev_.regs.pfqf_hkey),
       num_qs(num_qs_) {
   rxqs = new lan_queue_rx *[num_qs];

--- a/sims/nic/i40e_bm/i40e_queues.cc
+++ b/sims/nic/i40e_bm/i40e_queues.cc
@@ -37,7 +37,7 @@ namespace i40e {
 queue_base::queue_base(const std::string &qname_, uint32_t &reg_head_,
                        uint32_t &reg_tail_, i40e_bm &dev_)
     : qname(qname_),
-      log(qname_, dev_.runner_),
+      log(qname_, dev_),
       dev(dev_),
       active_first_pos(0),
       active_first_idx(0),

--- a/sims/nic/i40e_bm/logger.cc
+++ b/sims/nic/i40e_bm/logger.cc
@@ -28,15 +28,26 @@
 
 namespace i40e {
 
-logger::logger(const std::string &label_, nicbm::Runner *runner_)
-    : label(label_), runner(runner_) {
+logger::logger(const std::string &label_, nicbm::Runner::Device &dev_)
+    : label(label_), dev(dev_), runner(dev_.runner_) {
   ss << std::hex;
 }
 
 logger &logger::operator<<(char c) {
   if (c == endl) {
-    std::cerr << runner->TimePs() << " " << label << ": " << ss.str()
-              << std::endl;
+    uint64_t ts;
+
+    /* runner might not be initialized yet if called from a constructor
+     * somewhere, in that case see if it's set now otherwise just take 0 as the
+     * current timestamp. */
+    if (!runner) {
+      runner = dev.runner_;
+      ts = runner ? runner->TimePs() : 0;
+    } else {
+      ts = runner->TimePs();
+    }
+
+    std::cerr << ts << " " << label << ": " << ss.str() << std::endl;
     ss.str(std::string());
     ss << std::hex;
   } else {


### PR DESCRIPTION
Depending on the order some of the constructors get executed, instances of the logger can end up with a null pointer for the runner. This led to a segfault when calling TimePs() on that nullptr.

Here we fix this in two steps: first the logger takes a device pointer, which in turn contains a pointer to the runner that will eventually be initialized. Also fix up the logger to simply use 0 as a timestamp for log events before the runner is there.