### PR TITLE
QEMU: set pkgversion string to 'SimBricks'

### DIFF
--- a/sims/external/rules.mk
+++ b/sims/external/rules.mk
@@ -49,6 +49,7 @@ $(d)qemu/ready: $(d)qemu
 	+cd $< && ./configure \
 	    --target-list=x86_64-softmmu \
 	    --disable-werror \
+	    --with-pkgversion=SimBricks \
 	    --extra-cflags="-I$(abspath $(lib_dir))" \
 	    --extra-ldflags="-L$(abspath $(lib_dir))" \
 	    --enable-simbricks \


### PR DESCRIPTION
this gets rid of the non-fatal build error 'No names found, cannot describe anything'