### PR TITLE
hot-fix build process for images derived from base failing

### DIFF
--- a/images/scripts/install-base.sh
+++ b/images/scripts/install-base.sh
@@ -26,8 +26,6 @@ GRUB_CFG_FILE=/etc/default/grub.d/50-cloudimg-settings.cfg
 echo 'GRUB_DISABLE_OS_PROBER=true' >> $GRUB_CFG_FILE
 echo 'GRUB_HIDDEN_TIMEOUT=0' >> $GRUB_CFG_FILE
 echo 'GRUB_TIMEOUT=0' >> $GRUB_CFG_FILE
-echo "GRUB_CMDLINE_LINUX_DEFAULT=\"console=tty1 console=ttyS0 " \
-     "init=/home/ubuntu/guestinit.sh rw\"" >> $GRUB_CFG_FILE
 update-grub
 
 # with stupid ubuntu22 /lib is a symlink at which point just untaring to / will


### PR DESCRIPTION
At the moment, only hot-fixes #75. I still have to work on a proper solution for setting the necessary kernel boot parameters to run experiments for Simics.