### PR TITLE
orchestration: also run simulator instances without dependencies

### DIFF
--- a/experiments/simbricks/orchestration/runners.py
+++ b/experiments/simbricks/orchestration/runners.py
@@ -21,7 +21,6 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import asyncio
-import collections
 import itertools
 import shlex
 import traceback
@@ -57,9 +56,10 @@ class ExperimentBaseRunner(ABC):
 
     def sim_graph(self) -> tp.Dict[Simulator, tp.Set[Simulator]]:
         sims = self.exp.all_simulators()
-        graph = collections.defaultdict(set)
+        graph = {}
         for sim in sims:
             deps = sim.dependencies() + sim.extra_deps
+            graph[sim] = set()
             for d in deps:
                 graph[sim].add(d)
         return graph


### PR DESCRIPTION
So far, simulator instances not connected to any other instances were skipped accidentally when creating the graph. So if a simbricks config only includes a single instance, e.g. a gem5 then it just does not get run at all. This fixes the problem and makes sure even simulators without connections get added to the dependency graph used to figure out the order for running simulators.