### PR TITLE
docker/simbricks-run: enable out of tree runs

### DIFF
--- a/experiments/run.py
+++ b/experiments/run.py
@@ -109,7 +109,7 @@ def parse_args() -> argparse.Namespace:
         '--repo',
         metavar='DIR',
         type=str,
-        default='..',
+        default=os.path.dirname(__file__) + '/..',
         help='SimBricks repository directory'
     )
     g_env.add_argument(


### PR DESCRIPTION
This makes it easier to use simbricks-run outside of the simbricks tree in the container. E.g. for other projects that use the simbricks image to run tests/experiments in their repo. The path can still be manually overridden when needed by specifying `simbricks-run --repo=FOO`.