### PR TITLE
cleanup docker builds

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -11,7 +11,8 @@ RUN git submodule update --init sims/external/gem5 \
 RUN git submodule update --init sims/external/femu \
  && make -j `nproc` sims/external/femu/ready
 RUN git submodule update --init sims/external/ns-3 \
- && make -j `nproc` sims/external/ns-3/ready
+ && make -j `nproc` sims/external/ns-3/ready \
+ && bash docker/cleanup_ns3.sh
 ENV PYTHONPATH=/simbricks/experiments
 RUN sudo cp docker/simbricks-run /usr/bin/ \
  && sudo chmod 755 /usr/bin/simbricks-run

--- a/docker/cleanup_images.sh
+++ b/docker/cleanup_images.sh
@@ -2,4 +2,9 @@
 set -e
 rm -rf images/{packer,packer_cache}
 rm -rf images/output-*/*.raw
-rm -rf images/kernel/{kheaders,linux-5.4.46}
+rm -rf images/kernel/kheaders
+find images/kernel \
+    -maxdepth 1 \
+    -regex "^images/kernel/linux-[0-9]*\.[0-9]*\.[0-9]*$" \
+    -type d \
+    -exec rm -rf {} \;

--- a/docker/cleanup_ns3.sh
+++ b/docker/cleanup_ns3.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+mkdir -p sims/external/ns-3-new/
+cd sims/external/ns-3
+find build -name '*.o' -delete
+cp -r \
+  build/ \
+  cosim-run.sh \
+  cosim-dctcp-run.sh \
+  ../ns-3-new/
+cd ..
+git submodule deinit -f ns-3
+rm -rf ../../.git/modules/sims/external/ns-3
+rm -rf ns-3
+mv ns-3-new ns-3
+touch ns-3/ready


### PR DESCRIPTION
This fixes the `docker/cleanup_images.sh` script that partly broke after updating the kernel version in c64d3d0. It no longer removed the linux kernel source folder, since it still used the old version number. I switched to using a regex to avoid this issue in the future.

Additionally, this adds a cleanup script for ns-3 similar to those for qemu and gem5, as requested in #9.