### PR TITLE
orchestration/exectools.py: fix getting stuck on terminating components

### DIFF
--- a/experiments/simbricks/orchestration/exectools.py
+++ b/experiments/simbricks/orchestration/exectools.py
@@ -148,7 +148,8 @@ class Component(object):
         try:
             await asyncio.wait_for(self._proc.wait(), delay)
             return
-        except TimeoutError:
+        # before Python 3.11, asyncio.wait_for() throws asyncio.TimeoutError -_-
+        except (TimeoutError, asyncio.TimeoutError):
             print(
                 f'terminating component {self.cmd_parts[0]} '
                 f'pid {self._proc.pid}',
@@ -159,14 +160,13 @@ class Component(object):
         try:
             await asyncio.wait_for(self._proc.wait(), delay)
             return
-        except TimeoutError:
+        except (TimeoutError, asyncio.TimeoutError):
             print(
                 f'killing component {self.cmd_parts[0]} '
                 f'pid {self._proc.pid}',
                 flush=True
             )
             await self.kill()
-
         await self._proc.wait()
 
     async def started(self) -> None:

--- a/experiments/simbricks/orchestration/exectools.py
+++ b/experiments/simbricks/orchestration/exectools.py
@@ -94,7 +94,7 @@ class Component(object):
             self._read_stream(self._proc.stderr, self._consume_err)
         )
         rc = await self._proc.wait()
-        await asyncio.wait([stdout_handler, stderr_handler])
+        await asyncio.gather(stdout_handler, stderr_handler)
         await self.terminated(rc)
 
     async def send_input(self, bs: bytes, eof=False) -> None:
@@ -352,7 +352,7 @@ class Executor(abc.ABC):
             waiter = asyncio.create_task(self.await_file(p, *args, **kwargs))
             xs.append(waiter)
 
-        await asyncio.wait(xs)
+        await asyncio.gather(*xs)
 
 
 class LocalExecutor(Executor):

--- a/experiments/simbricks/orchestration/runners.py
+++ b/experiments/simbricks/orchestration/runners.py
@@ -128,7 +128,7 @@ class ExperimentBaseRunner(ABC):
             executor = self.sim_executor(host)
             task = asyncio.create_task(executor.send_file(path, self.verbose))
             copies.append(task)
-        await asyncio.wait(copies)
+        await asyncio.gather(*copies)
 
         # prepare all simulators in parallel
         sims = []
@@ -141,7 +141,7 @@ class ExperimentBaseRunner(ABC):
                 )
             )
             sims.append(task)
-        await asyncio.wait(sims)
+        await asyncio.gather(*sims)
 
     async def wait_for_sims(self) -> None:
         """Wait for simulators to terminate (the ones marked to wait on)."""
@@ -173,7 +173,7 @@ class ExperimentBaseRunner(ABC):
         for (executor, sock) in self.sockets:
             scs.append(asyncio.create_task(executor.rmtree(sock)))
         if scs:
-            await asyncio.wait(scs)
+            await asyncio.gather(*scs)
 
         # add all simulator components to the output
         for sim, sc in self.running:
@@ -197,7 +197,7 @@ class ExperimentBaseRunner(ABC):
                     sims.append(sim)
 
                 # wait for starts to complete
-                await asyncio.wait(starting)
+                await asyncio.gather(*starting)
 
                 for sim in sims:
                     ts.done(sim)

--- a/experiments/simbricks/orchestration/runtime/local.py
+++ b/experiments/simbricks/orchestration/runtime/local.py
@@ -207,7 +207,7 @@ class LocalParallelRuntime(Runtime):
             self._pending_jobs.add(job)
 
         # wait for all runs to finish
-        await asyncio.wait(self._pending_jobs)
+        await asyncio.gather(*self._pending_jobs)
 
     async def start(self) -> None:
         """Execute all defined runs."""
@@ -218,7 +218,7 @@ class LocalParallelRuntime(Runtime):
             for job in self._pending_jobs:
                 job.cancel()
             # wait for all runs to finish
-            await asyncio.wait(self._pending_jobs)
+            await asyncio.gather(*self._pending_jobs)
 
     def interrupt_handler(self) -> None:
         self._starter_task.cancel()


### PR DESCRIPTION
This was a funny one 😄
Basically, on almost every machine, our orchestration framework got stuck trying to terminate our `i40e_bm`. I was able to observe this in our containers but not on my local machine. The reason for that is actually that I'm using Python 3.11 and they decided to change something important about [`asyncio.wait_for()`](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for):
> Changed in version 3.11: Raises TimeoutError instead of asyncio.TimeoutError

So this meant that we caught the wrong exception in `Component.int_term_kill()`. The reason we didn't spot this earlier is that exceptions were swallowed by the call to `asyncio.wait()` in `runners.py:ExperimentBaseRunner.terminate_collect_sims()` when invoking `int_term_kill()`. Instead, we now also use `asyncio.gather()`, which forwards exceptions to the calling coroutine.