### PR TITLE
dump formatted JSON for experiments

### DIFF
--- a/experiments/simbricks/orchestration/experiment/experiment_output.py
+++ b/experiments/simbricks/orchestration/experiment/experiment_output.py
@@ -70,7 +70,7 @@ class ExpOutput(object):
     def dump(self, outpath: str) -> None:
         pathlib.Path(outpath).parent.mkdir(parents=True, exist_ok=True)
         with open(outpath, 'w', encoding='utf-8') as file:
-            json.dump(self.__dict__, file)
+            json.dump(self.__dict__, file, sort_keys=True, indent=4)
 
     def load(self, file: str) -> None:
         with open(file, 'r', encoding='utf-8') as fp:


### PR DESCRIPTION
This allows the produced output JSON files to be immediately opened by text editors. So far, everything is dumped without white-space into a single line, which for example makes VS Code crash on sufficiently large files.

I tested this for a bit now and didn't notice a subjective difference in writing the JSON output files after interrupting an experiment.