### PR TITLE
docker: install qemu(-img) to /usr/bin

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -15,4 +15,10 @@ RUN git submodule update --init sims/external/ns-3 \
  && bash docker/cleanup_ns3.sh
 ENV PYTHONPATH=/simbricks/experiments
 RUN sudo cp docker/simbricks-run /usr/bin/ \
- && sudo chmod 755 /usr/bin/simbricks-run
+ && sudo chmod 755 /usr/bin/simbricks-run \
+ && sudo ln -s /simbricks/sims/external/qemu/build/qemu-system-x86_64 \
+    /usr/bin/qemu-system-x86_64 \
+ && sudo ln -s /simbricks/sims/external/qemu/build/qemu-system-x86_64 \
+    /usr/bin/kvm \
+ && sudo ln -s /simbricks/sims/external/qemu/build/qemu-img \
+    /usr/bin/qemu-img

--- a/docker/Dockerfile.min
+++ b/docker/Dockerfile.min
@@ -15,4 +15,10 @@ COPY --chown=${USERNAME}:${USERNAME} --from=builder /simbricks /simbricks
 WORKDIR /simbricks
 ENV PYTHONPATH=/simbricks/experiments
 RUN sudo cp docker/simbricks-run /usr/bin/ \
- && sudo chmod 755 /usr/bin/simbricks-run
+ && sudo chmod 755 /usr/bin/simbricks-run \
+ && sudo ln -s /simbricks/sims/external/qemu/build/qemu-system-x86_64 \
+    /usr/bin/qemu-system-x86_64 \
+ && sudo ln -s /simbricks/sims/external/qemu/build/qemu-system-x86_64 \
+    /usr/bin/kvm \
+ && sudo ln -s /simbricks/sims/external/qemu/build/qemu-img \
+    /usr/bin/qemu-img

--- a/docker/Dockerfile.tofino
+++ b/docker/Dockerfile.tofino
@@ -77,8 +77,13 @@ RUN make -j `nproc` build-images-min COMPRESSED_IMAGES=true \
  && bash docker/cleanup_images.sh
 ENV PYTHONPATH=/simbricks/experiments
 RUN sudo cp docker/simbricks-run /usr/bin/ \
- && sudo chmod 755 /usr/bin/simbricks-run
-
+ && sudo chmod 755 /usr/bin/simbricks-run \
+ && sudo ln -s /simbricks/sims/external/qemu/build/qemu-system-x86_64 \
+    /usr/bin/qemu-system-x86_64 \
+ && sudo ln -s /simbricks/sims/external/qemu/build/qemu-system-x86_64 \
+    /usr/bin/kvm \
+ && sudo ln -s /simbricks/sims/external/qemu/build/qemu-img \
+    /usr/bin/qemu-img
 RUN mkdir /tofino
 COPY docker/bf-sde.tgz /tofino
 WORKDIR /tofino


### PR DESCRIPTION
This makes it easier for images that build on ours to use tools like packer without having to specify the full path