### PR TITLE
orchestration: absolue path check images

### DIFF
--- a/experiments/simbricks/orchestration/experiment/experiment_environment.py
+++ b/experiments/simbricks/orchestration/experiment/experiment_environment.py
@@ -66,11 +66,25 @@ class ExpEnv(object):
     def hdcopy_path(self, sim: 'simulators.Simulator') -> str:
         return f'{self.workdir}/hdcopy.{sim.name}'
 
-    def hd_path(self, hd_name: str) -> str:
-        return f'{self.repodir}/images/output-{hd_name}/{hd_name}'
+    @staticmethod
+    def is_absolute_exists(path: str) -> bool:
+        return os.path.isabs(path) and os.path.isfile(path)
 
-    def hd_raw_path(self, hd_name: str) -> str:
-        return f'{self.repodir}/images/output-{hd_name}/{hd_name}.raw'
+    def hd_path(self, hd_name_or_path: str) -> str:
+        if ExpEnv.is_absolute_exists(hd_name_or_path):
+            return hd_name_or_path
+        return (
+            f'{self.repodir}/images/output-{hd_name_or_path}/'
+            f'{hd_name_or_path}'
+        )
+
+    def hd_raw_path(self, hd_name_or_path: str) -> str:
+        if ExpEnv.is_absolute_exists(hd_name_or_path):
+            return f'{hd_name_or_path}.raw'
+        return (
+            f'{self.repodir}/images/output-{hd_name_or_path}/'
+            f'{hd_name_or_path}.raw'
+        )
 
     def cfgtar_path(self, sim: 'simulators.Simulator') -> str:
         return f'{self.workdir}/cfg.{sim.name}.tar'

--- a/experiments/simbricks/orchestration/nodeconfig.py
+++ b/experiments/simbricks/orchestration/nodeconfig.py
@@ -87,7 +87,7 @@ class NodeConfig():
         self.memory = 512
         """Amount of system memory in MB."""
         self.disk_image = 'base'
-        """Name of disk image to use."""
+        """Name of disk image to use or absolute path to image."""
         self.mtu = 1500
         """Networking MTU."""
         self.nockp = 0


### PR DESCRIPTION
ExpEnv: `hd_path` and `hd_path_raw` check if an absolute path is given as argument. This is set by using a nodeconfigs `disk_image` property. In case an absolute path is passed, it is returned unmodified. Otherwise the usual SimBricks image name resolution takes place.