### PR TITLE
docker: use build args to pass REGISTRY and TAG into Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,5 @@
-FROM simbricks/simbricks-base:latest
+ARG REGISTRY=
+ARG TAG=:latest
+FROM ${REGISTRY}simbricks/simbricks-base${TAG}
 RUN make -j `nproc` build-images-min COMPRESSED_IMAGES=true \
  && bash docker/cleanup_images.sh

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,6 @@
-FROM simbricks/simbricks-build:latest
+ARG REGISTRY=
+ARG TAG=:latest
+FROM ${REGISTRY}simbricks/simbricks-build${TAG}
 COPY . /simbricks
 WORKDIR /simbricks
 RUN make -j `nproc` ENABLE_VERILATOR=y

--- a/docker/Dockerfile.buildenv
+++ b/docker/Dockerfile.buildenv
@@ -1,3 +1,5 @@
+ARG REGISTRY=
+ARG TAG=:latest
 FROM ubuntu:jammy
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive \

--- a/docker/Dockerfile.dist-worker
+++ b/docker/Dockerfile.dist-worker
@@ -1,4 +1,6 @@
-FROM simbricks/simbricks:latest
+ARG REGISTRY=
+ARG TAG=:latest
+FROM ${REGISTRY}simbricks/simbricks${TAG}
 RUN apt-get update \
  && apt-get install -y \
 	openssh-server \

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -1,3 +1,5 @@
-FROM simbricks/simbricks-base:latest
+ARG REGISTRY=
+ARG TAG=:latest
+FROM ${REGISTRY}simbricks/simbricks-base${TAG}
 RUN make -j `nproc` build-images COMPRESSED_IMAGES=true \
  && bash docker/cleanup_images.sh

--- a/docker/Dockerfile.gem5opt
+++ b/docker/Dockerfile.gem5opt
@@ -1,4 +1,6 @@
-FROM simbricks/simbricks:latest
+ARG REGISTRY=
+ARG TAG=:latest
+FROM ${REGISTRY}simbricks/simbricks${TAG}
 RUN mv sims/external/gem5 sims/external/gem5-old \
  && git submodule update --init sims/external/gem5 \
  && make -j `nproc` sims/external/gem5/ready GEM5_VARIANT=opt \

--- a/docker/Dockerfile.min
+++ b/docker/Dockerfile.min
@@ -1,5 +1,7 @@
-FROM simbricks/simbricks:latest as builder
-FROM simbricks/simbricks-runenv:latest
+ARG REGISTRY=
+ARG TAG=:latest
+FROM ${REGISTRY}simbricks/simbricks${TAG} as builder
+FROM ${REGISTRY}simbricks/simbricks-runenv${TAG}
 # Add non-root user for vs code devcontainer.
 ARG USERNAME=simbricks
 ARG USER_UID=1000

--- a/docker/Dockerfile.runenv
+++ b/docker/Dockerfile.runenv
@@ -1,3 +1,5 @@
+ARG REGISTRY=
+ARG TAG=:latest
 FROM ubuntu:jammy
 RUN apt-get update \
  && apt-get install -y \

--- a/docker/Dockerfile.tofino
+++ b/docker/Dockerfile.tofino
@@ -1,3 +1,5 @@
+ARG REGISTRY=
+ARG TAG=:latest
 FROM ubuntu:focal
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive \

--- a/docker/rules.mk
+++ b/docker/rules.mk
@@ -23,8 +23,8 @@
 include mk/subdir_pre.mk
 
 # Configuration parameters to control docker image build
-# DOCKER_REGISTRY ?= docker.io/
-# DOCKER_TAG ?= :latest
+DOCKER_REGISTRY ?= docker.io/
+DOCKER_TAG ?= :latest
 
 DOCKER_IMAGES := simbricks/simbricks-build simbricks/simbricks-base \
   simbricks/simbricks simbricks/simbricks-runenv simbricks/simbricks-min \
@@ -33,30 +33,46 @@ DOCKER_IMAGES := simbricks/simbricks-build simbricks/simbricks-base \
 docker-images:
 	docker build -t \
 		$(DOCKER_REGISTRY)simbricks/simbricks-build$(DOCKER_TAG) \
+		--build-arg="REGISTRY=$(DOCKER_REGISTRY)" \
+		--build-arg="TAG=$(DOCKER_TAG)" \
 		-f docker/Dockerfile.buildenv docker
 	docker build -t \
 		$(DOCKER_REGISTRY)simbricks/simbricks-base$(DOCKER_TAG) \
+		--build-arg="REGISTRY=$(DOCKER_REGISTRY)" \
+		--build-arg="TAG=$(DOCKER_TAG)" \
 		-f docker/Dockerfile.base .
 	docker build -t \
 		$(DOCKER_REGISTRY)simbricks/simbricks$(DOCKER_TAG) \
+		--build-arg="REGISTRY=$(DOCKER_REGISTRY)" \
+		--build-arg="TAG=$(DOCKER_TAG)" \
 		-f docker/Dockerfile .
 	docker build -t \
 		$(DOCKER_REGISTRY)simbricks/simbricks-runenv$(DOCKER_TAG) \
+		--build-arg="REGISTRY=$(DOCKER_REGISTRY)" \
+		--build-arg="TAG=$(DOCKER_TAG)" \
 		-f docker/Dockerfile.runenv docker
 	docker build -t \
 		$(DOCKER_REGISTRY)simbricks/simbricks-min$(DOCKER_TAG) \
+		--build-arg="REGISTRY=$(DOCKER_REGISTRY)" \
+		--build-arg="TAG=$(DOCKER_TAG)" \
 		-f docker/Dockerfile.min docker
 	docker build -t \
 		$(DOCKER_REGISTRY)simbricks/simbricks-dist-worker$(DOCKER_TAG) \
+		--build-arg="REGISTRY=$(DOCKER_REGISTRY)" \
+		--build-arg="TAG=$(DOCKER_TAG)" \
 		-f docker/Dockerfile.dist-worker docker
 
 docker-images-debug:
 	docker build -t \
 		$(DOCKER_REGISTRY)simbricks/simbricks-gem5opt$(DOCKER_TAG) \
+		--build-arg="REGISTRY=$(DOCKER_REGISTRY)" \
+		--build-arg="TAG=$(DOCKER_TAG)" \
 		-f docker/Dockerfile.gem5opt docker
 
 docker-images-tofino:
-	docker build -t $(DOCKER_REGISTRY)simbricks/simbricks:tofino \
+	docker build -t $(DOCKER_REGISTRY)simbricks/simbricks-tofino$(DOCKER_TAG) \
+		--build-arg="REGISTRY=$(DOCKER_REGISTRY)" \
+		--build-arg="TAG=$(DOCKER_TAG)" \
 		-f docker/Dockerfile.tofino .
 
 docker-retag:


### PR DESCRIPTION
Before this, if registry or tag got set, we would still build all images starting from the docker hub registry version and latest tag.

This should hopefully fix our build issue of the docker images on our gitlab ci.