### PR TITLE
sims/external/gem5: update to gem5 23.1

### DIFF
--- a/docker/cleanup_gem5.sh
+++ b/docker/cleanup_gem5.sh
@@ -6,7 +6,6 @@ cd sims/external/gem5
 cp -r --parents \
   build/X86/gem5.fast \
   configs \
-  cache_conf.patch \
   ../gem5-new/
 #`find build -name \*.py` \
 cd ..

--- a/experiments/simbricks/orchestration/simulators.py
+++ b/experiments/simbricks/orchestration/simulators.py
@@ -463,9 +463,9 @@ class Gem5Host(HostSim):
         cmd = f'{env.gem5_path(self.variant)} --outdir={env.gem5_outdir(self)} '
         cmd += ' '.join(self.extra_main_args)
         cmd += (
-            f' {env.gem5_py_path} --caches --l2cache --l3cache '
-            '--l1d_size=32kB --l1i_size=32kB --l2_size=2MB --l3_size=32MB '
-            '--l1d_assoc=8 --l1i_assoc=8 --l2_assoc=4 --l3_assoc=16 '
+            f' {env.gem5_py_path} --caches --l2cache '
+            '--l1d_size=32kB --l1i_size=32kB --l2_size=32MB '
+            '--l1d_assoc=8 --l1i_assoc=8 --l2_assoc=16 '
             f'--cacheline_size=64 --cpu-clock={self.cpu_freq}'
             f' --sys-clock={self.sys_clock} '
             f'--checkpoint-dir={env.gem5_cpdir(self)} '
@@ -474,7 +474,7 @@ class Gem5Host(HostSim):
             f'--disk-image={env.cfgtar_path(self)} '
             f'--cpu-type={cpu_type} --mem-size={self.node_config.memory}MB '
             f'--num-cpus={self.node_config.cores} '
-            '--ddio-enabled --ddio-way-part=8 --mem-type=DDR4_2400_16x4 '
+            '--mem-type=DDR4_2400_16x4 '
         )
 
         if self.node_config.kcmd_append:

--- a/sims/external/rules.mk
+++ b/sims/external/rules.mk
@@ -37,10 +37,11 @@ $(d)gem5:
 	git clone https://github.com/simbricks/gem5.git $@
 
 $(d)gem5/ready: $(d)gem5
-	+cd $< && scons build/X86/gem5.$(GEM5_VARIANT) \
-		CCFLAGS="-I$(abspath $(lib_dir))" \
-		LIBPATH="$(abspath $(lib_dir))" \
-	    -j`nproc`
+	cd $< && \
+		CCFLAGS_EXTRA="-I$(abspath $(lib_dir))" \
+		LIBRARY_PATH="$(abspath $(lib_dir))" \
+		scons build/X86/gem5.$(GEM5_VARIANT) \
+		--ignore-style -j`nproc`
 	touch $@
 
 gem5-clean:


### PR DESCRIPTION
This updates the submodule pointer to the new gem5 version.

Note that this temporarily drops support for DDIO and the L3 cache, both of which we had manually patched in. We should add this back in later.