### PR TITLE
docker: add missing breathe package to buildenv image

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 breathe
+sphinx
 sphinx-rtd-theme

--- a/docker/Dockerfile.buildenv
+++ b/docker/Dockerfile.buildenv
@@ -25,6 +25,7 @@ RUN apt-get update \
 	libpcap-dev \
 	libpixman-1-dev \
 	libprotobuf-dev \
+	locales \
 	ninja-build \
 	protobuf-compiler \
 	python-is-python3 \
@@ -36,6 +37,7 @@ RUN apt-get update \
 	wget \
 	nano \
 	vim \
+ && locale-gen en_US.UTF-8 \
  && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt

--- a/docker/Dockerfile.buildenv
+++ b/docker/Dockerfile.buildenv
@@ -33,6 +33,7 @@ RUN apt-get update \
 	python3-pip \
 	rsync \
 	scons \
+	sudo \
 	unzip \
 	wget \
 	nano \
@@ -60,7 +61,5 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
  && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME --shell /bin/bash \
 # Add sudo support for this user and remove the need to type in password.
- && apt-get update \
- && apt-get install -y sudo \
  && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
  && chmod 0440 /etc/sudoers.d/$USERNAME

--- a/docker/Dockerfile.buildenv
+++ b/docker/Dockerfile.buildenv
@@ -30,8 +30,6 @@ RUN apt-get update \
 	python-is-python3 \
 	python3-dev \
 	python3-pip \
-	python3-sphinx \
-	python3-sphinx-rtd-theme \
 	rsync \
 	scons \
 	unzip \
@@ -40,7 +38,7 @@ RUN apt-get update \
 	vim \
  && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt
 COPY verilator.patch /tmp/
 RUN cd /tmp \
  && git clone -b v4.010 https://github.com/verilator/verilator \

--- a/docker/rules.mk
+++ b/docker/rules.mk
@@ -33,7 +33,7 @@ DOCKER_IMAGES := simbricks/simbricks-build simbricks/simbricks-base \
 REQUIREMENTS_TXT := $(d)requirements.txt
 
 $(REQUIREMENTS_TXT):
-	cp requirements.txt $@
+	cat requirements.txt doc/requirements.txt > $@
 
 docker-images: $(REQUIREMENTS_TXT)
 	docker build -t \


### PR DESCRIPTION
Otherwise make documentation fails in the devcontainer.