### PR TITLE
doc: fix logo size to full width of container

### DIFF
--- a/doc/simbricks-text-horizontal.svg
+++ b/doc/simbricks-text-horizontal.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 582.12 80.85">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 582.12 80.85" width="582.12" height="80.85">
   <defs>
     <style>
       .cls-1 {

--- a/doc/simbricks.svg
+++ b/doc/simbricks.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 193.87 164.94">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 193.87 164.94" width="193.87" height="164.94">
   <defs>
     <style>
       .cls-1 {


### PR DESCRIPTION
For some reason the new logo defaults to 0x0 px in the sphinx theme.