### PR TITLE
lib/simbricks/axil_manager: fix `step_apply()` sometimes being skipped 

### DIFF
--- a/lib/simbricks/axi/axi_subordinate.hh
+++ b/lib/simbricks/axi/axi_subordinate.hh
@@ -58,7 +58,7 @@ struct AXIOperation {
 
 /* Acts as the read part of an AXI Subordinate / Slave component */
 template <size_t BytesAddr, size_t BytesId, size_t BytesData,
-          size_t MaxInFlight = 64>
+          size_t MaxInFlight = 16>
 class AXISubordinateRead {
  public:
   static_assert(BytesAddr <= 8);
@@ -146,7 +146,7 @@ class AXISubordinateRead {
 
 /* Acts as the write part of an AXI Subordinate / Slave component */
 template <size_t BytesAddr, size_t BytesId, size_t BytesData,
-          size_t MaxInFlight = 64>
+          size_t MaxInFlight = 16>
 class AXISubordinateWrite {
  public:
   static_assert(BytesAddr <= 8);


### PR DESCRIPTION
I stumbled across this while trying to integrate xsim. @q713 This possibly also fixes your issues with the new corundum version.

Tested with JPEG decoder and VTA.