### PR TITLE
experiments/simbricks/orchestration/nodeconfig: config_files env parameter

### DIFF
--- a/experiments/simbricks/orchestration/runners.py
+++ b/experiments/simbricks/orchestration/runners.py
@@ -125,7 +125,7 @@ class ExperimentBaseRunner(ABC):
             path = self.env.cfgtar_path(host)
             if self.verbose:
                 print('preparing config tar:', path)
-            host.node_config.make_tar(path)
+            host.node_config.make_tar(self.env, path)
             executor = self.sim_executor(host)
             task = asyncio.create_task(executor.send_file(path, self.verbose))
             copies.append(task)


### PR DESCRIPTION
We should pass an additional experiment environment variable to the function config_file(...) of the NodeConfig class in experiments/simbricks/orchestration/nodeconfig allowing to properly define paths to needed resources.