### PR TITLE
verilator: bumped verilator version to v5.026 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ CPPFLAGS += -I$(base_dir)/lib -iquote$(base_dir) $(EXTRA_CPPFLAGS)
 VERILATOR = verilator
 VFLAGS = +1364-2005ext+v \
     -Wno-WIDTH -Wno-PINMISSING -Wno-LITENDIAN -Wno-IMPLICIT -Wno-SELRANGE \
-    -Wno-CASEINCOMPLETE -Wno-UNSIGNED $(EXTRA_VFLAGS)
+    -Wno-CASEINCOMPLETE -Wno-UNSIGNED --no-timing --timescale 1ps/1ps $(EXTRA_VFLAGS)
 
 
 $(eval $(call subdir,docker))

--- a/docker/Dockerfile.buildenv
+++ b/docker/Dockerfile.buildenv
@@ -43,13 +43,14 @@ RUN apt-get update \
 	wget \
 	nano \
 	vim \
+	help2man \
  && locale-gen en_US.UTF-8 \
  && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt
 COPY verilator.patch /tmp/
 RUN cd /tmp \
- && git clone -b v4.010 https://github.com/verilator/verilator \
+ && git clone -b v5.026 https://github.com/verilator/verilator \
  && cd verilator \
  && patch -p1 < /tmp/verilator.patch \
  && autoupdate \

--- a/sims/nic/rules.mk
+++ b/sims/nic/rules.mk
@@ -22,7 +22,7 @@
 
 include mk/subdir_pre.mk
 
-$(eval $(call subdir,corundum))
+# $(eval $(call subdir,corundum))
 $(eval $(call subdir,corundum_bm))
 $(eval $(call subdir,e1000_gem5))
 $(eval $(call subdir,i40e_bm))


### PR DESCRIPTION
- bumped verilator version to v5.026 
- new verilator flags to ensure compilation of existing verilog 
- no compilation of the RTL corundum version as it is planned to remove it from this repository anyways