### PR TITLE
lib/simbricks: rudimentary makefile target building core lib debian package

### DIFF
--- a/lib/simbricks/rules.mk
+++ b/lib/simbricks/rules.mk
@@ -39,7 +39,7 @@ $(lib_simbricks): $(libsimbricks_objs)
 
 
 pkg_name := simbricks-core-dev
-pkg_version := 0.0.1
+pkg_version := 0.3.6
 pkg_arch := amd64
 pkg_build_dir := /tmp
 pkg := $(pkg_name)_$(pkg_version)_$(pkg_arch)
@@ -48,7 +48,6 @@ pkg_debian_dir := $(pkg_dir)/DEBIAN
 pkg_control_file := $(pkg_debian_dir)/control
 pkg_lib_dir := $(pkg_dir)/usr/lib/simbricks
 pkg_header_dir := $(pkg_dir)/usr/include/simbricks
-lib_folders := axi base mem network nicbm nicif parser pcie
 
 lib_pkg := $(lib_dir)$(pkg).deb
 

--- a/lib/simbricks/rules.mk
+++ b/lib/simbricks/rules.mk
@@ -81,6 +81,12 @@ $(lib_pkg): $(lib_simbricks)
     # cleanup
 	rm -r $(pkg_dir)
 
+	@echo "Finished building debian package"
+
+package: $(lib_pkg)
+
+.PHONY: package
+
 CLEAN := $(lib_simbricks) $(lib_pkg)
 ALL := $(lib_simbricks)
 include mk/subdir_post.mk


### PR DESCRIPTION
This pull request adds a Makefile target to build a .deb package containing the SimBricks core C/C++ library.

The package created can be installed using apt / dpkg. After installation lib can be found under `/usr/lib/simbricks` and the respective header files under `/usr/include/simbricks`.