### PR TITLE
symphony/cli: add client factory methods to fix --ns cli option

### DIFF
--- a/symphony/cli/simbricks/cli/commands/instantiations.py
+++ b/symphony/cli/simbricks/cli/commands/instantiations.py
@@ -21,9 +21,9 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from typer import Typer
-from simbricks.client import simb_client
 from ..utils import async_cli
 from ..utils import print_table_generic
+from ..settings import simb_client
 
 app = Typer(help="Managing SimBricks Instantiations.")
 

--- a/symphony/cli/simbricks/cli/commands/namespaces.py
+++ b/symphony/cli/simbricks/cli/commands/namespaces.py
@@ -21,8 +21,8 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from typer import Typer
-from simbricks.client import ns_client
 from ..utils import async_cli, print_table_generic, print_members_table
+from ..settings import ns_client
 
 app = Typer(help="Managing SimBricks namespaces.")
 

--- a/symphony/cli/simbricks/cli/commands/rg.py
+++ b/symphony/cli/simbricks/cli/commands/rg.py
@@ -1,7 +1,7 @@
 from typer import Typer, Option
 from typing import Annotated
-from simbricks.client import rg_client
 from ..utils import async_cli, print_table_generic
+from ..settings import rg_client
 
 
 app = Typer(help="Managing SimBricks resource groups used by runners.")

--- a/symphony/cli/simbricks/cli/commands/runners.py
+++ b/symphony/cli/simbricks/cli/commands/runners.py
@@ -22,9 +22,8 @@
 
 from typer import Typer, Option
 from typing_extensions import Annotated
-from simbricks.client import runner_client
 from ..utils import async_cli, print_table_generic
-from simbricks.client.opus import base as opus_base
+from ..settings import runner_client
 
 app = Typer(help="Managing SimBricks runners.")
 

--- a/symphony/cli/simbricks/cli/commands/runs.py
+++ b/symphony/cli/simbricks/cli/commands/runs.py
@@ -20,18 +20,15 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import rich
 import typing
 from pathlib import Path
-
-import rich
 from typer import Argument, Option, Typer
 from typing_extensions import Annotated
-
 import simbricks.utils.load_mod as load_mod
 from simbricks.client.opus import base as opus_base
-from simbricks.client import simb_client
-
 from ..utils import async_cli, print_table_generic
+from ..settings import simb_client
 
 if typing.TYPE_CHECKING:
     from simbricks.orchestration.instantiation import base as inst_base

--- a/symphony/cli/simbricks/cli/commands/simulations.py
+++ b/symphony/cli/simbricks/cli/commands/simulations.py
@@ -21,9 +21,9 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from typer import Typer
-from simbricks.client import simb_client
 from ..utils import async_cli
 from ..utils import print_table_generic
+from ..settings import simb_client
 
 app = Typer(help="Managing SimBricks Simulations.")
 

--- a/symphony/cli/simbricks/cli/commands/systems.py
+++ b/symphony/cli/simbricks/cli/commands/systems.py
@@ -21,9 +21,9 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 from typer import Typer
-from simbricks.client import simb_client
 from ..utils import async_cli
 from ..utils import print_table_generic
+from ..settings import simb_client
 
 app = Typer(help="Managing SimBricks Systems.")
 

--- a/symphony/cli/simbricks/cli/settings.py
+++ b/symphony/cli/simbricks/cli/settings.py
@@ -2,7 +2,16 @@ from functools import lru_cache
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from simbricks.client.settings import ClientSettings
 from simbricks.telemetry.config import TelemetryConfig
-
+from simbricks.client import (
+    simb_client as client_simb_client,
+    SimBricksClient,
+    ns_client as client_ns_client,
+    NSClient,
+    rg_client as client_rg_client,
+    ResourceGroupClient,
+    runner_client as client_runner_client,
+    RunnerClient,
+)
 
 class CliSettings(BaseSettings):
     client: ClientSettings = ClientSettings()
@@ -17,3 +26,28 @@ class CliSettings(BaseSettings):
 @lru_cache
 def cli_settings() -> CliSettings:
     return CliSettings(_env_file="simbricks-cli.env", _env_file_encoding="utf-8")
+
+
+async def ns_client() -> NSClient:
+    base_url = cli_settings().client.base_url
+    ns_path = cli_settings().client.namespace
+    client = await client_ns_client(base_url, ns_path)
+    return client
+
+
+async def runner_client(runner_id: str) -> RunnerClient:
+    namespace_client = await ns_client()
+    client = await client_runner_client(runner_id, namespace_client)
+    return client
+
+
+async def rg_client() -> ResourceGroupClient:
+    namespace_client = await ns_client()
+    client = await client_rg_client(namespace_client)
+    return client
+
+
+async def simb_client() -> SimBricksClient:
+    namespace_client = await ns_client()
+    client = await client_simb_client(namespace_client)
+    return client


### PR DESCRIPTION
This pull requests fixes the currently broken `--ns` command line optionof the symphony/cli package.