### PR TITLE
Improve docker images

### DIFF
--- a/docker/Dockerfile.executor
+++ b/docker/Dockerfile.executor
@@ -75,7 +75,6 @@ RUN micromamba install -y simbricks-qemu-sim-bin \
 
 ENV GLOBAL_INPUT_DIR=/global_input
 
-COPY run_local_executor.sh /run_local_executor.sh
 COPY --chown=simbricks --from=image /image_builder/output/base/ /global_input/images/base/
 
 ENTRYPOINT ["/run_local_executor.sh"]

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -3,10 +3,10 @@ ARG TAG=:latest
 FROM ${REGISTRY}simbricks-baseenv${TAG}
 
 RUN micromamba install -y simbricks-runner \
-  && micromamba clean --all -y \
-  && rm -rf $MAMBA_ROOT_PREFIX/include
+  && micromamba clean --all -y
 
 COPY run_runner.sh /run_runner.sh
 COPY runner_config.yaml /runner_config.yaml
+COPY run_local_executor.sh /run_local_executor.sh
 
 ENTRYPOINT ["/run_runner.sh"]

--- a/docker/run_local_executor.sh
+++ b/docker/run_local_executor.sh
@@ -6,6 +6,7 @@ micromamba activate base
 ip=$1
 port=$2
 proxy_host_ip=$3
+convert=$4
 
 if [[ "$ip" = "" ]] || [[ "$port" = "" ]] || [[ "$proxy_host_ip" = "" ]]; then
     echo "Error: you need to specify both ip and port"
@@ -14,5 +15,15 @@ if [[ "$ip" = "" ]] || [[ "$port" = "" ]] || [[ "$proxy_host_ip" = "" ]]; then
 fi
 
 sudo chmod o+rw /dev/kvm
-qemu-img convert -f qcow2 -O raw -S 4k /global_input/images/base/base /global_input/images/base/base.raw
+
+# Try to convert images in global input dir to raw format
+if [ -d "$GLOBAL_INPUT_DIR" ] && [ "$convert" != "False" ] && [ "$convert" != "false" ]; then
+    for subdir in "$GLOBAL_INPUT_DIR"/images/*/; do
+        image_name="$(basename "$subdir")"
+        qemu-img convert -f qcow2 -O raw -S 4k \
+            "$GLOBAL_INPUT_DIR"/images/"$image_name"/"$image_name" \
+            "$GLOBAL_INPUT_DIR"/images/"$image_name"/"$image_name".raw
+    done
+fi
+
 exec simbricks-executor-local "$ip" "$port" "$proxy_host_ip"

--- a/symphony/runner/simbricks/runner/main_runner/plugins/docker_plugin.py
+++ b/symphony/runner/simbricks/runner/main_runner/plugins/docker_plugin.py
@@ -49,6 +49,7 @@ class SimbricksDockerPlugin(plugin.FragmentRunnerPlugin):
             "listen_ip": "0.0.0.0",
             "docker_image": "simbricks/simbricks-executor",
             "docker_pull": False,
+            "convert_images": True,
         }
 
         listen_ip = plugin.get_first_match("listen_ip", config_params, default_params)
@@ -85,6 +86,9 @@ class SimbricksDockerPlugin(plugin.FragmentRunnerPlugin):
             if pull.returncode != 0:
                 raise RuntimeError(f"docker pull of image {docker_image} failed")
 
+        convert_images = plugin.get_first_match("convert_images", config_params, default_params)
+        assert isinstance(convert_images, bool)
+
         if "docker_opts" in config_params:
             docker_opts = config_params["docker_opts"]
             if not isinstance(docker_opts, list):
@@ -105,7 +109,13 @@ class SimbricksDockerPlugin(plugin.FragmentRunnerPlugin):
                 "--add-host=host.docker.internal:host-gateway",
             ]
             + docker_opts
-            + [docker_image, "host.docker.internal", str(port), "host.docker.internal"]
+            + [
+                docker_image,
+                "host.docker.internal",
+                str(port),
+                "host.docker.internal",
+                str(convert_images),
+            ]
         )
 
         # wait for the fragment executor to connect


### PR DESCRIPTION
Add `run_local_executor.sh` to `simbricks-runner` image, so that executor images based on this already have the wrapper script. Also generalize image conversion in the wrapper script to common disk image layout in global input directory and add a config option to enable/disable conversion.