### PR TITLE
lib/simbricks/base/if.c: SimbricksBaseIfInit latency > 0

### DIFF
--- a/lib/simbricks/base/if.c
+++ b/lib/simbricks/base/if.c
@@ -148,6 +148,13 @@ size_t SimbricksBaseIfSHMSize(struct SimbricksBaseIfParams *params) {
 }
 
 int SimbricksBaseIfInit(struct SimbricksBaseIf *base_if, struct SimbricksBaseIfParams *params) {
+  /* a zero latency makes messages arrive at the timestamp they were sent at,
+     leaving the peer no window in which it can still process them */
+  if (params->link_latency == 0) {
+    fprintf(stderr, "SimbricksBaseIfInit: latency must be greater than zero\n");
+    return -1;
+  }
+
   /* ensure latency >= sync interval in synchronization case */
   bool must_check_sync = params->sync_mode == kSimbricksBaseIfSyncOptional ||
                          params->sync_mode == kSimbricksBaseIfSyncRequired;


### PR DESCRIPTION
This fixes https://github.com/simbricks/simbricks/issues/130 .

Note that sync interaval <= latency is already ensured:
https://github.com/simbricks/simbricks/blob/02eb956aea465ff805f7d7fe8ac1b5e8d8fd3321/lib/simbricks/base/if.c#L152-L159