### PR TITLE
Disk image boot artifact handling

### DIFF
--- a/symphony/orchestration/simbricks/orchestration/simulation/host.py
+++ b/symphony/orchestration/simbricks/orchestration/simulation/host.py
@@ -40,6 +40,9 @@ class HostSim(sim_base.Simulator):
         self._disk_images: dict[
             sys_host.FullSystemHost, list[tuple[disk_images.DiskImage, str]]
         ] = {}
+        self._boot_artifacts: dict[
+            sys_host.FullSystemHost, dict[disk_images.BootArtifact, str]
+        ] = {}
 
     def toJSON(self) -> dict:
         return super().toJSON()
@@ -48,6 +51,7 @@ class HostSim(sim_base.Simulator):
     def fromJSON(cls, simulation: sim_base.Simulation, json_obj: dict) -> tpe.Self:
         instance = super().fromJSON(simulation, json_obj)
         instance._disk_images = {}
+        instance._boot_artifacts = {}
         return instance
 
     def full_name(self) -> str:
@@ -80,6 +84,35 @@ class HostSim(sim_base.Simulator):
                 else:
                     host_disks.append((disk, disk.path(inst, disk.find_format(self))))
             self._disk_images[host] = host_disks
+
+    async def pull_boot_artifacts(
+        self,
+        inst: inst_base.Instantiation,
+        host: sys_host.FullSystemHost,
+        kinds: list[disk_images.BootArtifact],
+    ) -> None:
+        """Fetch @kinds from @host's first disk image and stash them for run_cmd.
+
+        Called from a simulator's prepare, naming every kind at once. run_cmd is
+        synchronous and cannot fetch, so it reads the stash via boot_artifact().
+        """
+        if not kinds:
+            return
+        host_disks = self._disk_images.get(host)
+        if not host_disks:
+            raise RuntimeError(f"{self.full_name()} has no disk image to take a kernel from")
+        # The first disk is the one the guest boots from, matching how run_cmd orders drives.
+        self._boot_artifacts[host] = await host_disks[0][0].boot_artifacts(inst, kinds)
+
+    def boot_artifact(self, host: sys_host.FullSystemHost, kind: disk_images.BootArtifact) -> str:
+        """Path of a boot artifact previously fetched by pull_boot_artifacts."""
+        artifacts = self._boot_artifacts.get(host)
+        if artifacts is None or kind not in artifacts:
+            raise RuntimeError(
+                f"boot artifact '{kind.value}' was not fetched for {host.name};"
+                " pull_boot_artifacts must request it during prepare"
+            )
+        return artifacts[kind]
 
     def supported_socket_types(self, interface: sys_base.Interface) -> set[inst_socket.SockType]:
         return {inst_socket.SockType.CONNECT}

--- a/symphony/orchestration/simbricks/orchestration/system/__init__.py
+++ b/symphony/orchestration/simbricks/orchestration/system/__init__.py
@@ -99,6 +99,7 @@ __all__ += [
 ]
 
 from simbricks.orchestration.system.disk_images import (
+    BootArtifact,
     ConfigFile,
     ConfigFileArtifact,
     ConfigFileLocal,
@@ -113,6 +114,7 @@ from simbricks.orchestration.system.disk_images import (
 )
 
 __all__ += [
+    "BootArtifact",
     "DiskImage",
     "DummyDiskImage",
     "ExternalDiskImage",

--- a/symphony/orchestration/simbricks/orchestration/system/disk_images.py
+++ b/symphony/orchestration/simbricks/orchestration/system/disk_images.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import abc
 import asyncio
+import enum
 import io
 import pathlib
 import tarfile
@@ -38,6 +39,19 @@ if tp.TYPE_CHECKING:
     from simbricks.orchestration.simulation import host as sim_host
     from simbricks.orchestration.system import base as sys_base
     from simbricks.orchestration.system.host import base as sys_host
+
+
+class BootArtifact(enum.Enum):
+    """A boot file inside a disk image that a simulator needs handed to it separately.
+
+    Simulators that boot a kernel themselves cannot read it out of the image, so the
+    image hands it over: QEMU takes the compressed kernel, gem5 the uncompressed ELF.
+    The value doubles as the file name.
+    """
+
+    VMLINUZ = "vmlinuz"
+    INITRD = "initrd"
+    VMLINUX = "vmlinux"
 
 
 class DiskImage(utils_base.IdObj):
@@ -58,6 +72,20 @@ class DiskImage(utils_base.IdObj):
     def assert_is_file(path: str) -> None:
         if not pathlib.Path(path).is_file():
             raise Exception(f"path={path} must be a file")
+
+    async def boot_artifacts(
+        self, inst: inst_base.Instantiation, kinds: list[BootArtifact]
+    ) -> dict[BootArtifact, str]:
+        """Boot files from inside this image, as paths keyed by kind.
+
+        Simulators ask for every kind at once, so an image that has to extract them
+        only pays for that once.
+        """
+        if not kinds:
+            return {}
+        raise RuntimeError(
+            f"{self.__class__.__name__} cannot provide boot artifacts {[k.value for k in kinds]}"
+        )
 
     async def _prepare_format(self, inst: inst_base.Instantiation, format: str) -> None:
         pass
@@ -124,9 +152,13 @@ class DummyDiskImage(DiskImage):
 
 # Disk image where user just provides a path
 class ExternalDiskImage(DiskImage):
-    def __init__(self, system: sys_base.System, path: str) -> None:
+    def __init__(self, system: sys_base.System, path: str, boot_dir: str | None = None) -> None:
         super().__init__(system)
         self._path = path
+        # Prebuilt boot artifacts, named after the BootArtifact values. Without it the
+        # image cannot serve boot_artifacts(): extracting them needs tooling core does
+        # not depend on.
+        self.boot_dir: str | None = boot_dir
         self.formats = ["raw", "qcow2"]
 
     def available_formats(self) -> list[str]:
@@ -137,9 +169,29 @@ class ExternalDiskImage(DiskImage):
         DiskImage.assert_is_file(path)
         return path
 
+    async def boot_artifacts(
+        self, inst: inst_base.Instantiation, kinds: list[BootArtifact]
+    ) -> dict[BootArtifact, str]:
+        if not kinds:
+            return {}
+        if self.boot_dir is None:
+            raise RuntimeError(
+                f"cannot provide boot artifacts {[k.value for k in kinds]} for disk image"
+                f" '{self._path}': pass boot_dir= naming the directory holding them, or set"
+                " the simulator's kernel path explicitly"
+            )
+        boot_dir = pathlib.Path(inst.env.work_dir_or_abs(self.boot_dir))
+        artifacts = {}
+        for kind in kinds:
+            path = (boot_dir / kind.value).as_posix()
+            DiskImage.assert_is_file(path)
+            artifacts[kind] = path
+        return artifacts
+
     def toJSON(self) -> dict:
         json_obj = super().toJSON()
         json_obj["path"] = self._path
+        json_obj["boot_dir"] = self.boot_dir
         json_obj["formats"] = self.formats
         return json_obj
 
@@ -147,6 +199,7 @@ class ExternalDiskImage(DiskImage):
     def fromJSON(cls, system: sys_base.System, json_obj: dict) -> tpe.Self:
         instance = super().fromJSON(system, json_obj)
         instance._path = utils_base.get_json_attr_top(json_obj, "path")
+        instance.boot_dir = utils_base.get_json_attr_top_or_none(json_obj, "boot_dir")
         instance.formats = utils_base.get_json_attr_top(json_obj, "formats")
         return instance
 
@@ -171,6 +224,15 @@ class DistroDiskImage(DiskImage):
             raise RuntimeError("Unsupported disk format")
         DiskImage.assert_is_file(path)
         return path
+
+    async def boot_artifacts(
+        self, inst: inst_base.Instantiation, kinds: list[BootArtifact]
+    ) -> dict[BootArtifact, str]:
+        # The image build extracts these next to the image itself, so this is a plain lookup.
+        return {
+            kind: inst.env.global_input_dir(f"images/{self.name}/boot/{kind.value}", True)
+            for kind in kinds
+        }
 
     def toJSON(self) -> dict:
         json_obj = super().toJSON()


### PR DESCRIPTION
Layers on top of #203.

Is preparation to pulling these out of custom images via commands in future commits. Part of the mess here is that run_md is not async so it cannot directly call the function to generate them, and iirc on purpose. But we have the prep call.