### PR TITLE
Fix: uniform time interval handling

### DIFF
--- a/doc/learn/orchestration-framework.rst
+++ b/doc/learn/orchestration-framework.rst
@@ -64,9 +64,12 @@ The System Configuration makes use of three key concepts:
 - **Channels:** Channels connect interfaces and act as communication paths. These Channels are later upon execution transformed into shared memory queues that link simulator instances.
 
 Channels are also where communication latencies are configured: each channel has a configurable
-link latency (e.g. ``channel.set_latency(500, utils_base.Time.Nanoseconds)``), which applies to the
-message flow between the two connected components. Some components have interfaces of different
-link types — for example, a NIC has a PCIe interface to connect to a host and an Ethernet interface
+link latency (e.g. ``channel.latency = TimeInterval.ns(500)`` or simply ``channel.latency = "500ns"``), which applies to the
+message flow between the two connected components. Time intervals are always specified with an
+explicit unit, either as a ``simbricks.utils.time.TimeInterval`` instance created through one of its factory methods
+(``TimeInterval.ps``, ``TimeInterval.ns``, ``TimeInterval.us``, ``TimeInterval.ms``, ``TimeInterval.s``) or as a unit suffixed string such
+as ``"500ns"`` or ``"1.5us"``. Some components have interfaces of
+different link types — for example, a NIC has a PCIe interface to connect to a host and an Ethernet interface
 to connect to the network — and the latencies can be configured individually per channel.
 
 Hosts additionally reference :ref:`disk images <sec-disk-images>` that define the software they
@@ -92,7 +95,7 @@ The ``simbricks.orchestration.simulation`` module provides the generic base clas
 **Synchronization.** SimBricks' default behavior is to execute virtual prototypes unsynchronized,
 which is sufficient for functional testing and fastest. For meaningful end-to-end performance
 measurements, synchronization must be enabled, e.g. through
-``sim.enable_synchronization(amount=500, ratio=utils_base.Time.Nanoseconds)`` on the ``Simulation``
+``sim.enable_synchronization("500ns")`` on the ``Simulation``
 object, which synchronizes all channels with the given synchronization period. Generally, for
 accurate simulations, you want to configure the synchronization period to the same value as the
 link latency: with a lower value you do not gain accuracy but send more synchronization messages

--- a/doc/learn/simulator-integration/implementation/index.rst
+++ b/doc/learn/simulator-integration/implementation/index.rst
@@ -149,6 +149,15 @@ Initialization
 
 * In :numref:`code-adapter-initialize` you can see the initialization code from our Corundum Verilator Adapter.
 
+.. note::
+
+  All time intervals in ``SimbricksBaseIfParams`` (``link_latency``, ``sync_interval``) are given in
+  **picoseconds**. The same holds for the time intervals in the SimBricks parameters url that the
+  orchestration framework passes to a simulator (``:latency=XX:sync_interval=XX``), which are plain
+  decimal picosecond values without a unit suffix. Adapters using
+  ``SimbricksParametersParse``/``SimbricksParametersEstablish`` must therefore not rescale the parsed
+  values.
+
 .. _code-adapter-initialize:
 
 .. code-block:: C++
@@ -368,11 +377,11 @@ Polling and Synchronization
       main_time = strtoull(argv[5], NULL, 0);
     if (argc >= 7)
       netParams.sync_interval = pcieParams.sync_interval =
-          strtoull(argv[6], NULL, 0) * 1000ULL;
+          strtoull(argv[6], NULL, 0);
     if (argc >= 8)
-      pcieParams.link_latency = strtoull(argv[7], NULL, 0) * 1000ULL;
+      pcieParams.link_latency = strtoull(argv[7], NULL, 0);
     if (argc >= 9)
-      netParams.link_latency = strtoull(argv[8], NULL, 0) * 1000ULL;
+      netParams.link_latency = strtoull(argv[8], NULL, 0);
     if (argc >= 10)
       clock_period = 1000000ULL / strtoull(argv[9], NULL, 0);
 

--- a/experiments/simple_data_center.py
+++ b/experiments/simple_data_center.py
@@ -28,7 +28,7 @@ if N_RACKS * N_DETAILED_HOSTS_PER_RACK % 2 != 0 or N_RACKS * N_NS3_HOSTS_PER_RAC
     print("Number of detailed hosts and ns-3 hosts must each be even")
     exit(1)
 
-LINK_LATENCY = 100000  # in nanoseconds
+LINK_LATENCY = "100us"
 LINK_BANDWIDTH_SPINE = "10Gbps"
 LINK_BANDWIDTH_TOR = "1Gbps"
 
@@ -63,7 +63,7 @@ for i_tor in range(N_RACKS):
     tor_switch = system.EthSwitch(sys)
     tor_switch.name = f"TOR Switch-{i_tor}"
     channel = sys_helpers.connect_eth_devices(spine_switch, tor_switch)
-    channel.set_latency(LINK_LATENCY)
+    channel.latency = LINK_LATENCY
     channel.parameters["data_rate"] = LINK_BANDWIDTH_SPINE
     tor_switches.append((tor_switch, channel))
 
@@ -77,7 +77,7 @@ for i_tor_switch in range(N_RACKS):
         host = Host(sys_host)
 
         channel = sys_helpers.connect_eth_devices(tor_switches[i_tor_switch][0], sys_host)
-        channel.set_latency(LINK_LATENCY)
+        channel.latency = LINK_LATENCY
         channel.parameters["data_rate"] = LINK_BANDWIDTH_TOR
         host.channel = channel
 
@@ -108,7 +108,7 @@ for i_tor_switch in range(N_RACKS):
         host.nic = nic
 
         channel = tor_switches[i_tor_switch][0].connect_eth_peer_if(nic._eth_if)
-        channel.set_latency(LINK_LATENCY)
+        channel.latency = LINK_LATENCY
         channel.parameters["data_rate"] = LINK_BANDWIDTH_TOR
         host.channel = channel
 

--- a/experiments/simple_ping_ns3.py
+++ b/experiments/simple_ping_ns3.py
@@ -62,21 +62,21 @@ switch = system.EthSwitch(sys)
 switch_nic0 = system.EthInterface(switch)
 switch.add_if(switch_nic0)
 switch_nic0_chan = system.EthChannel(nic0._eth_if, switch_nic0)
-switch_nic0_chan.latency = 2 * 10**6  # 2ms
+switch_nic0_chan.latency = "2ms"
 switch_nic1 = system.EthInterface(switch)
 switch.add_if(switch_nic1)
 switch_nic1_chan = system.EthChannel(nic1._eth_if, switch_nic1)
-switch_nic1_chan.latency = 2 * 10**6  # 2ms
+switch_nic1_chan.latency = "2ms"
 
 # # connect switch to ns-3 hosts
 # switch_host2 = system.EthInterface(switch)
 # switch.add_if(switch_host2)
 # switch_host2_chan = system.EthChannel(host2_eth_if, switch_host2)
-# switch_host2_chan.latency = 2 * 10**6 # 2ms
+# switch_host2_chan.latency = "2ms"
 # switch_host3 = system.EthInterface(switch)
 # switch.add_if(switch_host3)
 # switch_host3_chan = system.EthChannel(host3_eth_if, switch_host3)
-# switch_host3_chan.latency = 2 * 10**6 # 2ms
+# switch_host3_chan.latency = "2ms"
 
 # configure the software to run on the host
 sleep_app = system.Sleep(host0, infinite=True)

--- a/lib/simbricks/nicbm/nicbm.cc
+++ b/lib/simbricks/nicbm/nicbm.cc
@@ -604,13 +604,13 @@ int Runner::ParseArgs(int argc, char *argv[]) {
   netParams_.sync_mode = GetSyncMode(netAdapterParams_->sync);
 
   if (pcieAdapterParams_->sync_interval_set)
-    pcieParams_.sync_interval = pcieAdapterParams_->sync_interval * 1000ULL;
+    pcieParams_.sync_interval = pcieAdapterParams_->sync_interval;
   if (netAdapterParams_->sync_interval_set)
-    netParams_.sync_interval = netAdapterParams_->sync_interval * 1000ULL;
+    netParams_.sync_interval = netAdapterParams_->sync_interval;
   if (pcieAdapterParams_->link_latency_set)
-    pcieParams_.link_latency = pcieAdapterParams_->link_latency * 1000ULL;
+    pcieParams_.link_latency = pcieAdapterParams_->link_latency;
   if (netAdapterParams_->link_latency_set)
-    netParams_.link_latency = netAdapterParams_->link_latency * 1000ULL;
+    netParams_.link_latency = netAdapterParams_->link_latency;
 
   return 0;
 }

--- a/lib/simbricks/parser/parser.c
+++ b/lib/simbricks/parser/parser.c
@@ -59,6 +59,9 @@ static bool ParseUInteger(const char *str, uint64_t *val) {
 // SYNC = sync=<true|false>
 // ARGS = :latency=XX | :sync_interval=XX
 //
+// By convention all time intervals (latency, sync_interval) are given as plain
+// decimal picosecond values without a unit suffix.
+//
 // Returns NULL when a failure occured
 struct SimbricksAdapterParams *SimbricksParametersParse(const char *url) {
   struct SimbricksAdapterParams *params = malloc(sizeof(struct SimbricksAdapterParams));

--- a/lib/simbricks/parser/parser.h
+++ b/lib/simbricks/parser/parser.h
@@ -36,8 +36,10 @@ struct SimbricksAdapterParams {
   char *shm_path;
   bool sync;
   bool link_latency_set;
+  /** Link latency/propagation delay [picoseconds] */
   uint64_t link_latency;
   bool sync_interval_set;
+  /** Maximum gap between sync messages [picoseconds] */
   uint64_t sync_interval;
 };
 

--- a/symphony/orchestration/simbricks/orchestration/helpers/simulation.py
+++ b/symphony/orchestration/simbricks/orchestration/helpers/simulation.py
@@ -25,6 +25,7 @@ import typing
 from simbricks.orchestration import system
 from simbricks.orchestration.simulation import base as sim_base
 from simbricks.utils import base as utils_base
+from simbricks.utils import time as utils_time
 
 
 def add_specs(simulator: sim_base.Simulator, *specifications) -> None:
@@ -35,18 +36,14 @@ def add_specs(simulator: sim_base.Simulator, *specifications) -> None:
 
 
 def enable_sync_simulation(
-    simulation: sim_base.Simulation, amount: int | None = None, ratio: utils_base.Time | None = None
+    simulation: sim_base.Simulation, sync_period: utils_time.TimeInterval | str | None = None
 ) -> None:
     utils_base.has_expected_type(obj=simulation, expected_type=sim_base.Simulation)
-    set_period: bool = amount is not None and ratio is not None
-    if set_period:
-        assert isinstance(amount, int)
-        assert isinstance(ratio, utils_base.Time)
 
     for chan in simulation.get_all_channels():
         chan._synchronized = True
-        if amount is not None and ratio is not None:
-            chan.set_sync_period(amount=amount, ratio=ratio)
+        if sync_period is not None:
+            chan.sync_period = sync_period
 
 
 def disalbe_sync_simulation(simulation: sim_base.Simulation) -> None:

--- a/symphony/orchestration/simbricks/orchestration/simulation/base.py
+++ b/symphony/orchestration/simbricks/orchestration/simulation/base.py
@@ -33,6 +33,7 @@ import simbricks.orchestration.instantiation.socket as inst_socket
 import simbricks.orchestration.simulation.channel as sim_chan
 import simbricks.orchestration.system as sys_conf
 import simbricks.utils.base as utils_base
+import simbricks.utils.time as utils_time
 
 T = tp.TypeVar("T")
 
@@ -165,18 +166,20 @@ class Simulator(utils_base.IdObj):
     @staticmethod
     def get_unique_latency_period_sync(
         channels: list[sim_chan.Channel],
-    ) -> tuple[int, int, bool]:
+    ) -> tuple[utils_time.TimeInterval, utils_time.TimeInterval, bool]:
         latency = None
         sync_period = None
         run_sync = False
         for channel in channels:
             sync_period = (
-                min(sync_period, channel.sync_period) if sync_period else channel.sync_period
+                min(sync_period, channel.sync_period)
+                if sync_period is not None
+                else channel.sync_period
             )
             run_sync = run_sync or channel._synchronized
             latency = (
                 max(latency, channel.sys_channel.latency)
-                if latency
+                if latency is not None
                 else channel.sys_channel.latency
             )
         if latency is None or sync_period is None:
@@ -189,33 +192,43 @@ class Simulator(utils_base.IdObj):
         socket: inst_socket.Socket,
         channel: sim_chan.Channel | None = None,
         sync: bool | None = None,
-        latency: int | None = None,
-        sync_period: int | None = None,
+        latency: utils_time.TimeInterval | None = None,
+        sync_period: utils_time.TimeInterval | None = None,
     ) -> str:
-        if not channel and (sync is None or latency is None or sync_period is None):
+        """Build the parameters url handed to a simulator's SimBricks adapter.
+
+        By convention the time intervals in these urls are always given as plain
+        picosecond values without a unit suffix.
+        """
+        if channel is None and (sync is None or latency is None or sync_period is None):
             raise ValueError(
                 "Cannot generate parameters url if channel and at least one of sync, "
                 "latency, sync_period are None"
             )
-        if channel:
-            if not sync:
+        if channel is not None:
+            if sync is None:
                 sync = channel._synchronized
-            if not latency:
+            if latency is None:
                 latency = channel.sys_channel.latency
-            if not sync_period:
+            if sync_period is None:
                 sync_period = channel.sync_period
 
+        # MM: assertion to make pyright happy; IMHO it is not needed, since the code above makes
+        # sure that sync, latency, and sync_period are not None here.
+        assert latency is not None and sync_period is not None
         sync_str = "true" if sync else "false"
+        latency_ps = latency.picoseconds
+        sync_period_ps = sync_period.picoseconds
 
         if socket._type == inst_socket.SockType.CONNECT:
             return (
-                f"connect:{socket._path}:sync={sync_str}:latency={latency}"
-                f":sync_interval={sync_period}"
+                f"connect:{socket._path}:sync={sync_str}:latency={latency_ps}"
+                f":sync_interval={sync_period_ps}"
             )
         else:
             return (
                 f"listen:{socket._path}:{inst.env.get_simulator_shm_pool_path(self)}:sync={sync_str}"
-                f":latency={latency}:sync_interval={sync_period}"
+                f":latency={latency_ps}:sync_interval={sync_period_ps}"
             )
 
     def get_interface_url(
@@ -565,12 +578,12 @@ class Simulation(utils_base.IdObj):
         return all_channels
 
     def enable_synchronization(
-        self, amount: int | None = None, ratio: utils_base.Time | None = None
+        self, sync_period: utils_time.TimeInterval | str | None = None
     ) -> None:
         for chan in self.get_all_channels():
             chan._synchronized = True
-            if amount and ratio:
-                chan.set_sync_period(amount=amount, ratio=ratio)
+            if sync_period is not None:
+                chan.sync_period = sync_period
 
     def resreq_mem(self) -> int:
         """Memory required to run all simulators in this experiment."""

--- a/symphony/orchestration/simbricks/orchestration/simulation/channel.py
+++ b/symphony/orchestration/simbricks/orchestration/simulation/channel.py
@@ -27,25 +27,35 @@ import typing_extensions as tpe
 from simbricks.orchestration.simulation import base as sim_base
 from simbricks.orchestration.system import base as system_base
 from simbricks.utils import base as utils_base
+from simbricks.utils import time as utils_time
 
 
 class Channel(utils_base.IdObj):
     def __init__(self, chan: system_base.Channel):
         super().__init__()
         self._synchronized: bool = False
-        self.sync_period: int = 500  # nanoseconds
-        """
-        The synchronization period in nanoseconds. For SimBricks to function
-        properly in sync mode, the sync period must not be larger than a channels
-        latency.
-        """
-        assert self.sync_period <= chan.latency
+        self._sync_period = utils_time.TimeInterval.ns(500)
+        assert self._sync_period <= chan.latency
         self.sys_channel: system_base.Channel = chan
+
+    @property
+    def sync_period(self) -> utils_time.TimeInterval:
+        """
+        The synchronization period. For SimBricks to function properly in sync
+        mode, the sync period must not be larger than a channels latency.
+        """
+        return self._sync_period
+
+    @sync_period.setter
+    def sync_period(self, sync_period: utils_time.TimeInterval | str) -> None:
+        new_sync_period = utils_time.TimeInterval.from_value(sync_period)
+        assert new_sync_period <= self.sys_channel.latency
+        self._sync_period = new_sync_period
 
     def toJSON(self):
         json_obj = super().toJSON()
         json_obj["synchronized"] = self._synchronized
-        json_obj["sync_period"] = self.sync_period
+        json_obj["sync_period"] = self._sync_period.toJSON()
         json_obj["sys_channel"] = self.sys_channel.id()
         return json_obj
 
@@ -53,14 +63,9 @@ class Channel(utils_base.IdObj):
     def fromJSON(cls, simulation: sim_base.Simulation, json_obj: dict) -> tpe.Self:
         instance = super().fromJSON(json_obj)
         instance._synchronized = bool(utils_base.get_json_attr_top(json_obj, "synchronized"))
-        instance.sync_period = int(utils_base.get_json_attr_top(json_obj, "sync_period"))
+        instance._sync_period = utils_time.TimeInterval.fromJSON(
+            utils_base.get_json_attr_top(json_obj, "sync_period")
+        )
         chan_id = int(utils_base.get_json_attr_top(json_obj, "sys_channel"))
         instance.sys_channel = simulation.system.get_chan(chan_id)
         return instance
-
-    def set_sync_period(
-        self, amount: int, ratio: utils_base.Time = utils_base.Time.Nanoseconds
-    ) -> None:
-        utils_base.has_expected_type(obj=ratio, expected_type=utils_base.Time)
-        self.sync_period = amount * ratio
-        assert self.sync_period <= self.sys_channel.latency

--- a/symphony/orchestration/simbricks/orchestration/system/base.py
+++ b/symphony/orchestration/simbricks/orchestration/system/base.py
@@ -29,6 +29,7 @@ import typing_extensions as tpe
 
 from simbricks.orchestration.system import disk_images
 from simbricks.utils import base as utils_base
+from simbricks.utils import time as utils_time
 
 if tp.TYPE_CHECKING:
     from simbricks.orchestration.instantiation import base as inst_base
@@ -101,12 +102,12 @@ class System(utils_base.IdObj):
         return self._all_applications[ident]
 
     @staticmethod
-    def set_latencies(channels: list[Channel], amount: int, ratio: utils_base.Time) -> None:
+    def set_latencies(channels: list[Channel], latency: utils_time.TimeInterval | str) -> None:
         for chan in channels:
-            chan.set_latency(amount, ratio)
+            chan.latency = latency
 
     def latencies(
-        self, amount: int, ratio: utils_base.Time, channel_type: tp.Any | None = None
+        self, latency: utils_time.TimeInterval | str, channel_type: tp.Any | None = None
     ) -> None:
         relevant_channels = list(self._all_channels.values())
         if channel_type:
@@ -116,7 +117,7 @@ class System(utils_base.IdObj):
                     self._all_channels.values(),
                 )
             )
-        System.set_latencies(relevant_channels, amount, ratio)
+        System.set_latencies(relevant_channels, latency)
 
     def toJSON(self) -> dict:
         json_obj = super().toJSON()
@@ -385,7 +386,7 @@ class DummyInterface(Interface):
 class Channel(utils_base.IdObj):
     def __init__(self, a: Interface, b: Interface) -> None:
         super().__init__()
-        self.latency = 500  # nanoseconds
+        self._latency = utils_time.TimeInterval.ns(500)
         self.a: Interface = a
         self.a.connect(self)
         self.b: Interface = b
@@ -411,15 +412,18 @@ class Channel(utils_base.IdObj):
         assert opposing != interface
         return opposing
 
-    def set_latency(
-        self, amount: int, ratio: utils_base.Time = utils_base.Time.Nanoseconds
-    ) -> None:
-        utils_base.has_expected_type(obj=ratio, expected_type=utils_base.Time)
-        self.latency = amount * ratio
+    @property
+    def latency(self) -> utils_time.TimeInterval:
+        """Link latency/propagation delay of this channel."""
+        return self._latency
+
+    @latency.setter
+    def latency(self, latency: utils_time.TimeInterval | str) -> None:
+        self._latency = utils_time.TimeInterval.from_value(latency)
 
     def toJSON(self) -> dict:
         json_obj = super().toJSON()
-        json_obj["latency"] = self.latency
+        json_obj["latency"] = self._latency.toJSON()
         json_obj["interface_a"] = self.a.id()
         json_obj["interface_b"] = self.b.id()
         json_obj["parameters"] = utils_base.dict_to_json(self.parameters)
@@ -428,7 +432,9 @@ class Channel(utils_base.IdObj):
     @classmethod
     def fromJSON(cls, system: System, json_obj: dict) -> tpe.Self:
         instance = super().fromJSON(json_obj)
-        instance.latency = int(utils_base.get_json_attr_top(json_obj, "latency"))
+        instance._latency = utils_time.TimeInterval.fromJSON(
+            utils_base.get_json_attr_top(json_obj, "latency")
+        )
         instance.parameters = utils_base.json_to_dict(
             utils_base.get_json_attr_top(json_obj, "parameters")
         )

--- a/symphony/utils/simbricks/utils/base.py
+++ b/symphony/utils/simbricks/utils/base.py
@@ -64,15 +64,6 @@ class InputArtifactSource(abc.ABC):
         """Paths of the local files needed, relative to where the script defining them runs."""
 
 
-class Time(enum.IntEnum):
-    # FIXME: this is wrong, see https://github.com/simbricks/simbricks/issues/178
-    Picoseconds = 10 ** (-3)  # pyright: ignore[reportAssignmentType]
-    Nanoseconds = 1
-    Microseconds = 10 ** (3)
-    Milliseconds = 10 ** (6)
-    Seconds = 10 ** (9)
-
-
 def filter_None_dict(to_filter: dict) -> dict:
     res = {k: v for k, v in to_filter.items() if v is not None}
     return res

--- a/symphony/utils/simbricks/utils/time.py
+++ b/symphony/utils/simbricks/utils/time.py
@@ -34,8 +34,8 @@ from simbricks.utils import base as utils_base
 class TimeInterval:
     """An immutable time interval, stored as an integer number of picoseconds.
 
-    Instances are created through the per-unit factory methods (``Time.ns(500)``)
-    or by parsing a unit suffixed string (``Time.parse("500ns")``). Bare numbers
+    Instances are created through the per-unit factory methods (``TimeInterval.ns(500)``)
+    or by parsing a unit suffixed string (``TimeInterval.parse("500ns")``). Bare numbers
     are deliberately not accepted anywhere, they leave the unit implicit.
     """
 

--- a/symphony/utils/simbricks/utils/time.py
+++ b/symphony/utils/simbricks/utils/time.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Max Planck Institute for Software Systems,
+# National University of Singapore, and SimBricks UG (haftungsbeschränkt)
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import decimal
+import functools
+import re
+import typing as tp
+
+import typing_extensions as tpe
+
+from simbricks.utils import base as utils_base
+
+
+@functools.total_ordering
+class TimeInterval:
+    """An immutable time interval, stored as an integer number of picoseconds.
+
+    Instances are created through the per-unit factory methods (``Time.ns(500)``)
+    or by parsing a unit suffixed string (``Time.parse("500ns")``). Bare numbers
+    are deliberately not accepted anywhere, they leave the unit implicit.
+    """
+
+    _UNITS: tp.ClassVar[dict[str, int]] = {
+        "ps": 1,
+        "ns": 10**3,
+        "us": 10**6,
+        "ms": 10**9,
+        "s": 10**12,
+    }
+    _PATTERN: tp.ClassVar[re.Pattern] = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*(ps|ns|us|ms|s)\s*$")
+
+    __slots__ = ("_picoseconds",)
+
+    def __init__(self, picoseconds: int) -> None:
+        if isinstance(picoseconds, bool) or not isinstance(picoseconds, int):
+            raise TypeError(f"picoseconds must be an int, got {type(picoseconds)}")
+        if picoseconds < 0:
+            raise ValueError(f"time interval must not be negative, got {picoseconds}ps")
+        object.__setattr__(self, "_picoseconds", picoseconds)
+
+    def __setattr__(self, name: str, value: tp.Any) -> None:
+        raise AttributeError(f"{type(self).__name__} is immutable")
+
+    @property
+    def picoseconds(self) -> int:
+        """The interval as a whole number of picoseconds."""
+        return self._picoseconds
+
+    @classmethod
+    def _from_decimal(cls, amount: decimal.Decimal, unit: str, label: str) -> tpe.Self:
+        picoseconds = amount * cls._UNITS[unit]
+        if picoseconds != picoseconds.to_integral_value():
+            raise ValueError(f"{label} is not a whole number of picoseconds")
+        return cls(int(picoseconds))
+
+    @classmethod
+    def _from_amount(cls, amount: int | float, unit: str) -> tpe.Self:
+        if isinstance(amount, bool) or not isinstance(amount, (int, float)):
+            raise TypeError(f"time amount must be an int or float, got {type(amount)}")
+        return cls._from_decimal(decimal.Decimal(str(amount)), unit, f"{amount}{unit}")
+
+    @classmethod
+    def ps(cls, amount: int | float) -> tpe.Self:
+        return cls._from_amount(amount, "ps")
+
+    @classmethod
+    def ns(cls, amount: int | float) -> tpe.Self:
+        return cls._from_amount(amount, "ns")
+
+    @classmethod
+    def us(cls, amount: int | float) -> tpe.Self:
+        return cls._from_amount(amount, "us")
+
+    @classmethod
+    def ms(cls, amount: int | float) -> tpe.Self:
+        return cls._from_amount(amount, "ms")
+
+    @classmethod
+    def s(cls, amount: int | float) -> tpe.Self:
+        return cls._from_amount(amount, "s")
+
+    @classmethod
+    def parse(cls, value: str) -> tpe.Self:
+        """Parse a unit suffixed string like ``"500ns"`` or ``"1.5us"``."""
+        if not isinstance(value, str):
+            raise TypeError(f"time interval string must be a str, got {type(value)}")
+        match = cls._PATTERN.match(value)
+        if match is None:
+            raise ValueError(
+                f"cannot parse '{value}' as a time interval, expected an amount followed by one of"
+                f" {', '.join(cls._UNITS)}, e.g. '500ns'"
+            )
+        return cls._from_decimal(decimal.Decimal(match.group(1)), match.group(2), value.strip())
+
+    @classmethod
+    def from_value(cls, value: "TimeInterval | str") -> "TimeInterval":
+        """Coerce the accepted user facing representations into a ``Time``."""
+        if isinstance(value, TimeInterval):
+            return value
+        if isinstance(value, str):
+            return cls.parse(value)
+        raise TypeError(
+            f"time interval must be a {cls.__name__} instance or a unit suffixed string like"
+            f" '500ns', got {type(value)}"
+        )
+
+    def __str__(self) -> str:
+        for unit, factor in reversed(self._UNITS.items()):
+            if self._picoseconds % factor == 0:
+                return f"{self._picoseconds // factor}{unit}"
+        return f"{self._picoseconds}ps"
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}.parse('{self}')"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TimeInterval):
+            return NotImplemented
+        return self._picoseconds == other._picoseconds
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, TimeInterval):
+            return NotImplemented
+        return self._picoseconds < other._picoseconds
+
+    def __hash__(self) -> int:
+        return hash(self._picoseconds)
+
+    def __bool__(self) -> bool:
+        return self._picoseconds != 0
+
+    def __add__(self, other: "TimeInterval") -> "TimeInterval":
+        if not isinstance(other, TimeInterval):
+            return NotImplemented
+        return TimeInterval(self._picoseconds + other._picoseconds)
+
+    def __sub__(self, other: "TimeInterval") -> "TimeInterval":
+        if not isinstance(other, TimeInterval):
+            return NotImplemented
+        return TimeInterval(self._picoseconds - other._picoseconds)
+
+    def __mul__(self, factor: int | float) -> "TimeInterval":
+        if isinstance(factor, bool) or not isinstance(factor, (int, float)):
+            return NotImplemented
+        picoseconds = decimal.Decimal(self._picoseconds) * decimal.Decimal(str(factor))
+        if picoseconds != picoseconds.to_integral_value():
+            raise ValueError(f"scaling {self} by {factor} is not a whole number of picoseconds")
+        return TimeInterval(int(picoseconds))
+
+    __rmul__ = __mul__
+
+    def toJSON(self) -> dict:
+        return {
+            "type": type(self).__qualname__,
+            "module": type(self).__module__,
+            "picoseconds": self._picoseconds,
+        }
+
+    @classmethod
+    def fromJSON(cls, json_obj: dict) -> tpe.Self:
+        if not isinstance(json_obj, dict):
+            raise TypeError(
+                f"cannot deserialize a time interval from {type(json_obj)}. Time intervals are"
+                " serialized as objects carrying a 'picoseconds' field. A bare number most likely"
+                " stems from an outdated configuration that stored nanoseconds."
+            )
+        return cls(int(utils_base.get_json_attr_top(json_obj, "picoseconds")))


### PR DESCRIPTION
Fixes #178.

Introduces a new `TimeInterval` class to cleanly represent and parse time intervals. In the orchestration framework time intervals can now be given as an instance of `TimeInterval` or as a string with a time unit (e.g. `"500ns"`). Time intervals given to SimBricks adapters (e.g. in the parameters URLs) are always in picoseconds without a unit.

This PR requires changes in SimBricks adapters and Python code setting time intervals of orchestration framework objects (channel latency, channel sync interval, ...).