### PR TITLE
Do not fail while retrieving boot artifacts

### DIFF
--- a/symphony/imagebuild-guestfs/simbricks/imagebuild/guestfs/image.py
+++ b/symphony/imagebuild-guestfs/simbricks/imagebuild/guestfs/image.py
@@ -420,11 +420,5 @@ class GuestfsImage(image_layers.LayeredDiskImage):
         for kind in kinds:
             src = out_dir / pathlib.PurePosixPath(guest_names[kind]).name
             if not src.is_file():
-                msg = f"'{guest_names[kind]}' is not in this image."
-                if kind is disk_images.BootArtifact.VMLINUX:
-                    msg += (
-                        " An uncompressed vmlinux comes from the kernel's debug"
-                        " package; add a layer that installs it."
-                    )
-                raise RuntimeError(msg)
+                continue
             src.rename(out_dir / kind.value)

--- a/symphony/imagebuild-packer/simbricks/imagebuild/packer/image.py
+++ b/symphony/imagebuild-packer/simbricks/imagebuild/packer/image.py
@@ -343,14 +343,4 @@ class PackerImage(image_layers.LayeredDiskImage):
     ) -> None:
         # The build downloads these from the guest, so reaching here means the
         # image came from the cache and its entry does not have them.
-        missing = [k.value for k in kinds]
-        msg = (
-            f"{missing} not available for this image: packer collects boot artifacts while"
-            " it builds, and this image was not built in this run."
-        )
-        if disk_images.BootArtifact.VMLINUX in kinds:
-            msg += (
-                " An uncompressed vmlinux also needs the kernel's debug package"
-                " installed by a layer."
-            )
-        raise RuntimeError(msg)
+        pass

--- a/symphony/orchestration/simbricks/orchestration/simulation/host.py
+++ b/symphony/orchestration/simbricks/orchestration/simulation/host.py
@@ -104,15 +104,20 @@ class HostSim(sim_base.Simulator):
         # The first disk is the one the guest boots from, matching how run_cmd orders drives.
         self._boot_artifacts[host] = await host_disks[0][0].boot_artifacts(inst, kinds)
 
+    def check_boot_artifact(
+        self, host: sys_host.FullSystemHost, kind: disk_images.BootArtifact
+    ) -> bool:
+        artifacts = self._boot_artifacts.get(host)
+        return artifacts is not None and kind in artifacts
+
     def boot_artifact(self, host: sys_host.FullSystemHost, kind: disk_images.BootArtifact) -> str:
         """Path of a boot artifact previously fetched by pull_boot_artifacts."""
-        artifacts = self._boot_artifacts.get(host)
-        if artifacts is None or kind not in artifacts:
+        if not self.check_boot_artifact(host, kind):
             raise RuntimeError(
                 f"boot artifact '{kind.value}' was not fetched for {host.name};"
                 " pull_boot_artifacts must request it during prepare"
             )
-        return artifacts[kind]
+        return self._boot_artifacts[host][kind]
 
     def supported_socket_types(self, interface: sys_base.Interface) -> set[inst_socket.SockType]:
         return {inst_socket.SockType.CONNECT}

--- a/symphony/orchestration/simbricks/orchestration/system/disk_images.py
+++ b/symphony/orchestration/simbricks/orchestration/system/disk_images.py
@@ -122,16 +122,13 @@ class DiskImage(utils_base.IdObj):
     async def boot_artifacts(
         self, inst: inst_base.Instantiation, kinds: list[BootArtifact]
     ) -> dict[BootArtifact, str]:
-        """Boot files from inside this image, as paths keyed by kind.
+        """Boot files from inside this image, as paths keyed by kind. Only successfully retrieved
+        boot artifacts are returned. Simulators later check if boot artifact is actually available.
 
         Simulators ask for every kind at once, so an image that has to extract them
         only pays for that once.
         """
-        if not kinds:
-            return {}
-        raise RuntimeError(
-            f"{self.__class__.__name__} cannot provide boot artifacts {[k.value for k in kinds]}"
-        )
+        return {}
 
     async def _prepare_format(self, inst: inst_base.Instantiation, format: str) -> None:
         pass
@@ -208,8 +205,6 @@ class DummyDiskImage(DiskImage):
     async def boot_artifacts(
         self, inst: inst_base.Instantiation, kinds: list[BootArtifact]
     ) -> dict[BootArtifact, str]:
-        if not kinds:
-            return {}
         raise self._unavailable("boot_artifacts")
 
     @classmethod
@@ -246,20 +241,14 @@ class ExternalDiskImage(DiskImage):
     async def boot_artifacts(
         self, inst: inst_base.Instantiation, kinds: list[BootArtifact]
     ) -> dict[BootArtifact, str]:
-        if not kinds:
+        if not kinds or self.boot_dir is None:
             return {}
-        if self.boot_dir is None:
-            raise RuntimeError(
-                f"cannot provide boot artifacts {[k.value for k in kinds]} for disk image"
-                f" '{self._path}': pass boot_dir= naming the directory holding them, or set"
-                " the simulator's kernel path explicitly"
-            )
         boot_dir = pathlib.Path(inst.env.work_dir_or_abs(self.boot_dir))
         artifacts = {}
         for kind in kinds:
-            path = (boot_dir / kind.value).as_posix()
-            DiskImage.assert_is_file(path)
-            artifacts[kind] = path
+            path = boot_dir / kind.value
+            if path.is_file():
+                artifacts[kind] = path.as_posix()
         return artifacts
 
     def toJSON(self) -> dict:
@@ -374,20 +363,14 @@ class HttpDiskImage(DynamicDiskImage):
     async def boot_artifacts(
         self, inst: inst_base.Instantiation, kinds: list[BootArtifact]
     ) -> dict[BootArtifact, str]:
-        if not kinds:
+        if not kinds or self.boot_dir is None:
             return {}
-        if self.boot_dir is None:
-            raise RuntimeError(
-                f"cannot provide boot artifacts {[k.value for k in kinds]} for '{self.url}':"
-                " pass boot_dir= naming a directory on the runner holding them, build a"
-                " layered image on this one, or set the simulator's kernel path explicitly"
-            )
         boot_dir = pathlib.Path(inst.env.work_dir_or_abs(self.boot_dir))
         artifacts = {}
         for kind in kinds:
-            path = (boot_dir / kind.value).as_posix()
-            DiskImage.assert_is_file(path)
-            artifacts[kind] = path
+            path = boot_dir / kind.value
+            if path.is_file():
+                artifacts[kind] = path.as_posix()
         return artifacts
 
     def _fetch(self, out: str) -> None:

--- a/symphony/orchestration/simbricks/orchestration/system/image_layers.py
+++ b/symphony/orchestration/simbricks/orchestration/system/image_layers.py
@@ -443,8 +443,11 @@ class LayeredDiskImage(disk_images.DynamicDiskImage, utils_base.InputArtifactSou
             if cache is None:
                 if wanted:
                     await self._produce_boot_artifacts(inst, wanted, out_dir)
-                self._check_boot_artifacts(kinds, out_dir)
-                return {k: (out_dir / k.value).as_posix() for k in kinds}
+                return {
+                    k: (out_dir / k.value).as_posix()
+                    for k in kinds
+                    if (out_dir / k.value).is_file()
+                }
 
             # Under the entry's lock: a sweep in another run may be evicting,
             # and it leaves alone whatever is held.
@@ -457,23 +460,18 @@ class LayeredDiskImage(disk_images.DynamicDiskImage, utils_base.InputArtifactSou
                         wanted.remove(kind)
                 if wanted:
                     await self._produce_boot_artifacts(inst, wanted, out_dir)
-                self._check_boot_artifacts(kinds, out_dir)
                 for kind in kinds:
                     # Also for the ones the build itself collected, which is how
                     # a backend that only gets them while building survives a hit.
-                    if cache.boot_artifact(digest, kind.value) is None:
+                    if (out_dir / kind.value).is_file() and cache.boot_artifact(
+                        digest, kind.value
+                    ) is None:
                         cache.store_boot_artifact(
                             digest, kind.value, (out_dir / kind.value).as_posix()
                         )
                 cache.used(digest)
 
-        return {k: (out_dir / k.value).as_posix() for k in kinds}
-
-    @staticmethod
-    def _check_boot_artifacts(kinds: list[disk_images.BootArtifact], out_dir: pathlib.Path) -> None:
-        for kind in kinds:
-            if not (out_dir / kind.value).is_file():
-                raise RuntimeError(f"'{kind.value}' was not produced for this image")
+        return {k: (out_dir / k.value).as_posix() for k in kinds if (out_dir / k.value).is_file()}
 
     async def _produce_boot_artifacts(
         self,
@@ -483,9 +481,7 @@ class LayeredDiskImage(disk_images.DynamicDiskImage, utils_base.InputArtifactSou
     ) -> None:
         """Put @kinds into @out_dir, named by kind. Called only for the ones
         neither this run nor the cache already has."""
-        raise RuntimeError(
-            f"{self.__class__.__name__} cannot provide boot artifacts {[k.value for k in kinds]}"
-        )
+        pass
 
     @abc.abstractmethod
     async def build(


### PR DESCRIPTION
Instead of the current approach of failing if a boot artifact could not be retrieved via `boot_artifacts`, now try to retrieve as much as possible and just return the boot artifacts that could be retrieved. Simulators later check and potentially fail, if boot artifacts are available. This allows simulators (like qemu) to choose a run command dynamically depending on which boot artifacts are available.